### PR TITLE
fix: workspace scaffolding — remove premature demo members, add scaffold comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,13 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "canon-demo-shared"
-version = "0.1.0"
-dependencies = [
- "canon-core",
-]
-
-[[package]]
 name = "canon-event-store"
 version = "0.1.0"
 dependencies = [
@@ -146,53 +139,4 @@ version = "0.1.0"
 dependencies = [
  "canon-core",
  "canon-snapshot-store",
-]
-
-[[package]]
-name = "cargo-service"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "fleet-service"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "frontend"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "gateway"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "navigation-service"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "station-service"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
-]
-
-[[package]]
-name = "supply-service"
-version = "0.1.0"
-dependencies = [
- "canon-demo-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,6 @@ members = [
     "canon-adaptor-kafka",
     "canon-deadletter",
     "canon-deadletter-pg",
-    "canon-demo/shared",
-    "canon-demo/fleet-service",
-    "canon-demo/cargo-service",
-    "canon-demo/navigation-service",
-    "canon-demo/supply-service",
-    "canon-demo/station-service",
-    "canon-demo/gateway",
-    "canon-demo/frontend",
 ]
 
 [workspace.dependencies]

--- a/canon-adaptor-kafka/src/lib.rs
+++ b/canon-adaptor-kafka/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-adaptor/src/lib.rs
+++ b/canon-adaptor/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-command-store-pg/src/lib.rs
+++ b/canon-command-store-pg/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-command-store/src/lib.rs
+++ b/canon-command-store/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-core/src/lib.rs
+++ b/canon-core/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-deadletter-pg/src/lib.rs
+++ b/canon-deadletter-pg/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-deadletter/src/lib.rs
+++ b/canon-deadletter/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-event-store-cassandra/src/lib.rs
+++ b/canon-event-store-cassandra/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-event-store/src/lib.rs
+++ b/canon-event-store/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-inbox-pg/src/lib.rs
+++ b/canon-inbox-pg/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-inbox/src/lib.rs
+++ b/canon-inbox/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-projection-store-pg/src/lib.rs
+++ b/canon-projection-store-pg/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-projection-store/src/lib.rs
+++ b/canon-projection-store/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-publisher-kafka/src/lib.rs
+++ b/canon-publisher-kafka/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-publisher/src/lib.rs
+++ b/canon-publisher/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-queue-rabbitmq/src/lib.rs
+++ b/canon-queue-rabbitmq/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-queue/src/lib.rs
+++ b/canon-queue/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-snapshot-store-pg/src/lib.rs
+++ b/canon-snapshot-store-pg/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold

--- a/canon-snapshot-store/src/lib.rs
+++ b/canon-snapshot-store/src/lib.rs
@@ -1,0 +1,1 @@
+// Phase 1 scaffold


### PR DESCRIPTION
## Summary
- Remove 7 `canon-demo/*` members from workspace root — these should not be included until their phase
- Add `// Phase 1 scaffold` comment to all 19 `src/lib.rs` files per spec
- `cargo check --workspace` passes clean (zero errors, zero warnings)

## Test plan
- [x] `cargo check --workspace` passes with zero errors and zero warnings
- [x] All 19 framework crates present as workspace members
- [x] No `canon-demo` crates in workspace members

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)