### PR TITLE
Wave 2b — canon-core in-memory implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,8 @@ dependencies = [
  "chrono",
  "futures",
  "serde",
+ "thiserror",
+ "tokio",
  "uuid",
 ]
 
@@ -647,6 +649,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/canon-core/Cargo.toml
+++ b/canon-core/Cargo.toml
@@ -10,3 +10,7 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
 futures = "0.3"
+thiserror = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt"] }

--- a/canon-core/src/lib.rs
+++ b/canon-core/src/lib.rs
@@ -1,9 +1,21 @@
 pub mod types;
 pub mod traits;
+pub mod memory;
 
 pub use types::*;
 pub use traits::{
     Aggregate, CommandHandler, EventHandler,
     Projection, ProjectionStore,
     CounterfactualReplay,
+};
+pub use memory::{
+    InMemoryEventStore, EventStoreError,
+    InMemoryCommandStore, CommandStoreError,
+    InMemorySnapshotStore, SnapshotStoreError,
+    InMemoryInbox, InboxError,
+    InMemoryQueue, QueueError,
+    InMemoryProjectionStore, ProjectionStoreError,
+    InMemoryPublisher, PublisherError,
+    InMemoryAdaptor, AdaptorError,
+    InMemoryDeadLetterStore, InMemoryDeadLetter, DeadLetterError,
 };

--- a/canon-core/src/memory/adaptor.rs
+++ b/canon-core/src/memory/adaptor.rs
@@ -1,0 +1,105 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::EventEnvelope;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdaptorError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryAdaptor {
+    inner: Arc<Mutex<VecDeque<EventEnvelope>>>,
+}
+
+impl InMemoryAdaptor {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Inject an external event into the adaptor. Used in tests to simulate
+    /// events arriving from other services.
+    pub fn inject(&self, event: EventEnvelope) -> Result<(), AdaptorError> {
+        let mut queue = self.inner.lock().map_err(|_| AdaptorError::Poisoned)?;
+        queue.push_back(event);
+        Ok(())
+    }
+
+    /// Drain the internal queue and return events as a stream.
+    pub fn subscribe(
+        &self,
+    ) -> Result<impl futures::Stream<Item = EventEnvelope>, AdaptorError> {
+        let mut queue = self.inner.lock().map_err(|_| AdaptorError::Poisoned)?;
+        let events: Vec<EventEnvelope> = queue.drain(..).collect();
+        Ok(futures::stream::iter(events))
+    }
+}
+
+impl Default for InMemoryAdaptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use futures::StreamExt;
+    use uuid::Uuid;
+    use crate::{AggregateId, Version};
+
+    fn make_event() -> EventEnvelope {
+        EventEnvelope {
+            event_id: Uuid::new_v4(),
+            aggregate_id: AggregateId::new(),
+            version: Version::initial().next(),
+            event_type: "ExternalEvent".into(),
+            event_version: 1,
+            payload: Bytes::from_static(b"{}"),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn inject_and_subscribe() {
+        let adaptor = InMemoryAdaptor::new();
+        adaptor.inject(make_event()).unwrap();
+        adaptor.inject(make_event()).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let events: Vec<_> = rt.block_on(async {
+            let stream = adaptor.subscribe().unwrap();
+            stream.collect().await
+        });
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn subscribe_drains_queue() {
+        let adaptor = InMemoryAdaptor::new();
+        adaptor.inject(make_event()).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let events: Vec<_> = rt.block_on(async {
+            adaptor.subscribe().unwrap().collect().await
+        });
+        assert_eq!(events.len(), 1);
+
+        let events: Vec<_> = rt.block_on(async {
+            adaptor.subscribe().unwrap().collect().await
+        });
+        assert!(events.is_empty());
+    }
+}

--- a/canon-core/src/memory/command_store.rs
+++ b/canon-core/src/memory/command_store.rs
@@ -1,0 +1,96 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{AggregateId, CommandEnvelope};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommandStoreError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryCommandStore {
+    inner: Arc<Mutex<Vec<CommandEnvelope>>>,
+}
+
+impl InMemoryCommandStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Append a command to the audit trail.
+    pub fn append(&self, envelope: CommandEnvelope) -> Result<(), CommandStoreError> {
+        let mut store = self.inner.lock().map_err(|_| CommandStoreError::Poisoned)?;
+        store.push(envelope);
+        Ok(())
+    }
+
+    /// Load commands for an aggregate, optionally filtered by timestamp range.
+    pub fn load_range(
+        &self,
+        aggregate_id: &AggregateId,
+        from: Option<chrono::DateTime<chrono::Utc>>,
+        to: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<CommandEnvelope>, CommandStoreError> {
+        let store = self.inner.lock().map_err(|_| CommandStoreError::Poisoned)?;
+        Ok(store
+            .iter()
+            .filter(|c| {
+                c.aggregate_id == *aggregate_id
+                    && from.is_none_or(|f| c.timestamp >= f)
+                    && to.is_none_or(|t| c.timestamp <= t)
+            })
+            .cloned()
+            .collect())
+    }
+}
+
+impl Default for InMemoryCommandStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn make_command(aggregate_id: &AggregateId) -> CommandEnvelope {
+        CommandEnvelope {
+            command_id: Uuid::new_v4(),
+            aggregate_id: aggregate_id.clone(),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            payload: Bytes::from_static(b"{}"),
+        }
+    }
+
+    #[test]
+    fn append_and_load() {
+        let store = InMemoryCommandStore::new();
+        let id = AggregateId::new();
+        store.append(make_command(&id)).unwrap();
+        store.append(make_command(&id)).unwrap();
+
+        let loaded = store.load_range(&id, None, None).unwrap();
+        assert_eq!(loaded.len(), 2);
+    }
+
+    #[test]
+    fn load_range_filters_by_aggregate() {
+        let store = InMemoryCommandStore::new();
+        let id_a = AggregateId::new();
+        let id_b = AggregateId::new();
+        store.append(make_command(&id_a)).unwrap();
+        store.append(make_command(&id_b)).unwrap();
+
+        let loaded = store.load_range(&id_a, None, None).unwrap();
+        assert_eq!(loaded.len(), 1);
+    }
+}

--- a/canon-core/src/memory/dead_letter.rs
+++ b/canon-core/src/memory/dead_letter.rs
@@ -1,0 +1,169 @@
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::AggregateId;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeadLetterError {
+    #[error("dead letter not found: {0}")]
+    NotFound(Uuid),
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Debug, Clone)]
+pub struct InMemoryDeadLetter {
+    pub id: Uuid,
+    pub message_id: Uuid,
+    pub handler_id: String,
+    pub aggregate_id: AggregateId,
+    pub payload: Bytes,
+    pub error: String,
+    pub attempts: u32,
+    pub created_at: DateTime<Utc>,
+    pub last_attempted: DateTime<Utc>,
+    pub requeue: bool,
+}
+
+#[derive(Clone)]
+pub struct InMemoryDeadLetterStore {
+    inner: Arc<Mutex<Vec<InMemoryDeadLetter>>>,
+}
+
+impl InMemoryDeadLetterStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Store a new dead letter entry.
+    pub fn store(
+        &self,
+        message_id: Uuid,
+        handler_id: &str,
+        aggregate_id: &AggregateId,
+        payload: Bytes,
+        error: &str,
+    ) -> Result<Uuid, DeadLetterError> {
+        let mut store = self.inner.lock().map_err(|_| DeadLetterError::Poisoned)?;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        store.push(InMemoryDeadLetter {
+            id,
+            message_id,
+            handler_id: handler_id.to_owned(),
+            aggregate_id: aggregate_id.clone(),
+            payload,
+            error: error.to_owned(),
+            attempts: 1,
+            created_at: now,
+            last_attempted: now,
+            requeue: false,
+        });
+        Ok(id)
+    }
+
+    /// List dead letters, optionally filtered by handler_id.
+    pub fn list(
+        &self,
+        handler_id: Option<&str>,
+    ) -> Result<Vec<InMemoryDeadLetter>, DeadLetterError> {
+        let store = self.inner.lock().map_err(|_| DeadLetterError::Poisoned)?;
+        Ok(store
+            .iter()
+            .filter(|dl| handler_id.is_none_or(|h| dl.handler_id == h))
+            .cloned()
+            .collect())
+    }
+
+    /// Mark a dead letter for requeue.
+    pub fn requeue(&self, id: Uuid) -> Result<(), DeadLetterError> {
+        let mut store = self.inner.lock().map_err(|_| DeadLetterError::Poisoned)?;
+        let entry = store
+            .iter_mut()
+            .find(|dl| dl.id == id)
+            .ok_or(DeadLetterError::NotFound(id))?;
+        entry.requeue = true;
+        Ok(())
+    }
+
+    /// Remove a dead letter entirely.
+    pub fn discard(&self, id: Uuid) -> Result<(), DeadLetterError> {
+        let mut store = self.inner.lock().map_err(|_| DeadLetterError::Poisoned)?;
+        let pos = store
+            .iter()
+            .position(|dl| dl.id == id)
+            .ok_or(DeadLetterError::NotFound(id))?;
+        store.remove(pos);
+        Ok(())
+    }
+}
+
+impl Default for InMemoryDeadLetterStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_and_list() {
+        let store = InMemoryDeadLetterStore::new();
+        let id = AggregateId::new();
+        store
+            .store(Uuid::new_v4(), "h1", &id, Bytes::from_static(b"{}"), "boom")
+            .unwrap();
+        store
+            .store(Uuid::new_v4(), "h2", &id, Bytes::from_static(b"{}"), "crash")
+            .unwrap();
+
+        assert_eq!(store.list(None).unwrap().len(), 2);
+        assert_eq!(store.list(Some("h1")).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn requeue_sets_flag() {
+        let store = InMemoryDeadLetterStore::new();
+        let id = AggregateId::new();
+        let dl_id = store
+            .store(Uuid::new_v4(), "h1", &id, Bytes::from_static(b"{}"), "err")
+            .unwrap();
+
+        store.requeue(dl_id).unwrap();
+        let entries = store.list(None).unwrap();
+        assert!(entries[0].requeue);
+    }
+
+    #[test]
+    fn discard_removes_entry() {
+        let store = InMemoryDeadLetterStore::new();
+        let id = AggregateId::new();
+        let dl_id = store
+            .store(Uuid::new_v4(), "h1", &id, Bytes::from_static(b"{}"), "err")
+            .unwrap();
+
+        store.discard(dl_id).unwrap();
+        assert!(store.list(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn requeue_not_found() {
+        let store = InMemoryDeadLetterStore::new();
+        let result = store.requeue(Uuid::new_v4());
+        assert!(matches!(result, Err(DeadLetterError::NotFound(_))));
+    }
+
+    #[test]
+    fn discard_not_found() {
+        let store = InMemoryDeadLetterStore::new();
+        let result = store.discard(Uuid::new_v4());
+        assert!(matches!(result, Err(DeadLetterError::NotFound(_))));
+    }
+}

--- a/canon-core/src/memory/event_store.rs
+++ b/canon-core/src/memory/event_store.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::{AggregateId, EventEnvelope, Version};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EventStoreError {
+    #[error("version conflict: expected {expected}, found {found}")]
+    VersionConflict { expected: u64, found: u64 },
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryEventStore {
+    inner: Arc<Mutex<HashMap<AggregateId, Vec<EventEnvelope>>>>,
+}
+
+impl InMemoryEventStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Append events for an aggregate. Rejects the write if `expected_version`
+    /// does not match the current stored version (optimistic concurrency).
+    pub fn append(
+        &self,
+        aggregate_id: &AggregateId,
+        expected_version: Version,
+        mut events: Vec<EventEnvelope>,
+    ) -> Result<(), EventStoreError> {
+        let mut store = self.inner.lock().map_err(|_| EventStoreError::Poisoned)?;
+        let stored = store.entry(aggregate_id.clone()).or_default();
+
+        let current_version = stored
+            .last()
+            .map(|e| e.version)
+            .unwrap_or_else(Version::initial);
+
+        if current_version != expected_version {
+            return Err(EventStoreError::VersionConflict {
+                expected: expected_version.as_u64(),
+                found: current_version.as_u64(),
+            });
+        }
+
+        let mut version = expected_version;
+        for event in &mut events {
+            version = version.next();
+            event.version = version;
+        }
+        stored.extend(events);
+        Ok(())
+    }
+
+    /// Load all events for an aggregate in ascending version order.
+    pub fn load(&self, aggregate_id: &AggregateId) -> Result<Vec<EventEnvelope>, EventStoreError> {
+        let store = self.inner.lock().map_err(|_| EventStoreError::Poisoned)?;
+        Ok(store.get(aggregate_id).cloned().unwrap_or_default())
+    }
+
+    /// Load events for an aggregate where version >= from_version.
+    pub fn load_from_version(
+        &self,
+        aggregate_id: &AggregateId,
+        from_version: Version,
+    ) -> Result<Vec<EventEnvelope>, EventStoreError> {
+        let store = self.inner.lock().map_err(|_| EventStoreError::Poisoned)?;
+        Ok(store
+            .get(aggregate_id)
+            .map(|events| {
+                events
+                    .iter()
+                    .filter(|e| e.version >= from_version)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+}
+
+impl Default for InMemoryEventStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn make_event(aggregate_id: &AggregateId) -> EventEnvelope {
+        EventEnvelope {
+            event_id: Uuid::new_v4(),
+            aggregate_id: aggregate_id.clone(),
+            version: Version::initial(),
+            event_type: "TestEvent".into(),
+            event_version: 1,
+            payload: Bytes::from_static(b"{}"),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn append_and_load() {
+        let store = InMemoryEventStore::new();
+        let id = AggregateId::new();
+        let events = vec![make_event(&id), make_event(&id)];
+        store.append(&id, Version::initial(), events).unwrap();
+
+        let loaded = store.load(&id).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].version.as_u64(), 1);
+        assert_eq!(loaded[1].version.as_u64(), 2);
+    }
+
+    #[test]
+    fn rejects_wrong_expected_version() {
+        let store = InMemoryEventStore::new();
+        let id = AggregateId::new();
+        let events = vec![make_event(&id)];
+        store.append(&id, Version::initial(), events).unwrap();
+
+        let result = store.append(&id, Version::initial(), vec![make_event(&id)]);
+        assert!(matches!(result, Err(EventStoreError::VersionConflict { .. })));
+    }
+
+    #[test]
+    fn load_from_version_filters() {
+        let store = InMemoryEventStore::new();
+        let id = AggregateId::new();
+        store
+            .append(&id, Version::initial(), vec![make_event(&id), make_event(&id), make_event(&id)])
+            .unwrap();
+
+        let loaded = store.load_from_version(&id, Version::initial().next().next()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].version.as_u64(), 2);
+        assert_eq!(loaded[1].version.as_u64(), 3);
+    }
+}

--- a/canon-core/src/memory/inbox.rs
+++ b/canon-core/src/memory/inbox.rs
@@ -1,0 +1,222 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use uuid::Uuid;
+
+use crate::{AggregateId, IncomingMessage, Oversight};
+
+#[derive(Debug, thiserror::Error)]
+pub enum InboxError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+type OversightFn = Box<dyn Fn(&[IncomingMessage]) -> Oversight + Send + Sync>;
+
+struct InboxState {
+    dedup: HashSet<(String, Uuid)>,
+    windows: HashMap<(String, AggregateId), Vec<IncomingMessage>>,
+    oversight: HashMap<String, OversightFn>,
+    dispatched: Vec<Vec<IncomingMessage>>,
+}
+
+/// In-memory inbox that faithfully reproduces the PostgreSQL inbox behaviour:
+/// deduplication, windowed accumulation, and oversight-driven dispatch.
+#[derive(Clone)]
+pub struct InMemoryInbox {
+    inner: Arc<Mutex<InboxState>>,
+}
+
+impl InMemoryInbox {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(InboxState {
+                dedup: HashSet::new(),
+                windows: HashMap::new(),
+                oversight: HashMap::new(),
+                dispatched: Vec::new(),
+            })),
+        }
+    }
+
+    /// Register an oversight function for the given handler.
+    pub fn register_handler<F>(&self, handler_id: &str, oversight_fn: F) -> Result<(), InboxError>
+    where
+        F: Fn(&[IncomingMessage]) -> Oversight + Send + Sync + 'static,
+    {
+        let mut state = self.inner.lock().map_err(|_| InboxError::Poisoned)?;
+        state
+            .oversight
+            .insert(handler_id.to_owned(), Box::new(oversight_fn));
+        Ok(())
+    }
+
+    /// Submit a message to the inbox for a specific handler.
+    ///
+    /// 1. Dedup check — if already seen, return Ok immediately
+    /// 2. Insert into dedup set
+    /// 3. Append message to the handler+aggregate window
+    /// 4. Evaluate oversight:
+    ///    - Ready → drain window, store as dispatched batch
+    ///    - NotReady → do nothing
+    ///    - Discard → clear window without dispatching
+    pub fn submit(
+        &self,
+        handler_id: &str,
+        message: IncomingMessage,
+    ) -> Result<(), InboxError> {
+        let mut state = self.inner.lock().map_err(|_| InboxError::Poisoned)?;
+
+        let message_id = message.message_id();
+        let dedup_key = (handler_id.to_owned(), message_id);
+        if state.dedup.contains(&dedup_key) {
+            return Ok(());
+        }
+        state.dedup.insert(dedup_key);
+
+        let aggregate_id = message.aggregate_id().clone();
+        let window_key = (handler_id.to_owned(), aggregate_id);
+        state.windows.entry(window_key.clone()).or_default().push(message);
+
+        let decision = {
+            let window = state.windows.get(&window_key).map(|v| v.as_slice()).unwrap_or(&[]);
+            state
+                .oversight
+                .get(handler_id)
+                .map(|f| f(window))
+                .unwrap_or(Oversight::Ready)
+        };
+
+        match decision {
+            Oversight::Ready => {
+                let batch = state.windows.remove(&window_key).unwrap_or_default();
+                state.dispatched.push(batch);
+            }
+            Oversight::NotReady => {}
+            Oversight::Discard => {
+                state.windows.remove(&window_key);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Drain all dispatched batches. Used by the orchestrator / tests to
+    /// consume ready batches for processing.
+    pub fn take_dispatched(&self) -> Result<Vec<Vec<IncomingMessage>>, InboxError> {
+        let mut state = self.inner.lock().map_err(|_| InboxError::Poisoned)?;
+        Ok(std::mem::take(&mut state.dispatched))
+    }
+}
+
+impl Default for InMemoryInbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+
+    fn make_command(aggregate_id: &AggregateId) -> IncomingMessage {
+        IncomingMessage::Command(crate::CommandEnvelope {
+            command_id: Uuid::new_v4(),
+            aggregate_id: aggregate_id.clone(),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            payload: Bytes::from_static(b"{}"),
+        })
+    }
+
+    fn make_command_with_id(aggregate_id: &AggregateId, command_id: Uuid) -> IncomingMessage {
+        IncomingMessage::Command(crate::CommandEnvelope {
+            command_id,
+            aggregate_id: aggregate_id.clone(),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            payload: Bytes::from_static(b"{}"),
+        })
+    }
+
+    #[test]
+    fn deduplicates_same_handler_and_message() {
+        let inbox = InMemoryInbox::new();
+        let id = AggregateId::new();
+        let cmd_id = Uuid::new_v4();
+
+        inbox.submit("h1", make_command_with_id(&id, cmd_id)).unwrap();
+        inbox.submit("h1", make_command_with_id(&id, cmd_id)).unwrap();
+
+        let batches = inbox.take_dispatched().unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+    }
+
+    #[test]
+    fn dispatches_on_ready() {
+        let inbox = InMemoryInbox::new();
+        let id = AggregateId::new();
+
+        inbox.submit("h1", make_command(&id)).unwrap();
+
+        let batches = inbox.take_dispatched().unwrap();
+        assert_eq!(batches.len(), 1);
+    }
+
+    #[test]
+    fn holds_on_not_ready() {
+        let inbox = InMemoryInbox::new();
+        let id = AggregateId::new();
+
+        inbox
+            .register_handler("h1", |_| Oversight::NotReady)
+            .unwrap();
+        inbox.submit("h1", make_command(&id)).unwrap();
+
+        let batches = inbox.take_dispatched().unwrap();
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn discards_without_dispatching() {
+        let inbox = InMemoryInbox::new();
+        let id = AggregateId::new();
+
+        inbox
+            .register_handler("h1", |_| Oversight::Discard)
+            .unwrap();
+        inbox.submit("h1", make_command(&id)).unwrap();
+
+        let batches = inbox.take_dispatched().unwrap();
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn oversight_accumulates_until_ready() {
+        let inbox = InMemoryInbox::new();
+        let id = AggregateId::new();
+
+        inbox
+            .register_handler("h1", |accumulated| {
+                if accumulated.len() >= 2 {
+                    Oversight::Ready
+                } else {
+                    Oversight::NotReady
+                }
+            })
+            .unwrap();
+
+        inbox.submit("h1", make_command(&id)).unwrap();
+        assert!(inbox.take_dispatched().unwrap().is_empty());
+
+        inbox.submit("h1", make_command(&id)).unwrap();
+        let batches = inbox.take_dispatched().unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 2);
+    }
+}

--- a/canon-core/src/memory/mod.rs
+++ b/canon-core/src/memory/mod.rs
@@ -1,0 +1,19 @@
+pub mod event_store;
+pub mod command_store;
+pub mod snapshot_store;
+pub mod inbox;
+pub mod queue;
+pub mod projection_store;
+pub mod publisher;
+pub mod adaptor;
+pub mod dead_letter;
+
+pub use event_store::{InMemoryEventStore, EventStoreError};
+pub use command_store::{InMemoryCommandStore, CommandStoreError};
+pub use snapshot_store::{InMemorySnapshotStore, SnapshotStoreError};
+pub use inbox::{InMemoryInbox, InboxError};
+pub use queue::{InMemoryQueue, QueueError};
+pub use projection_store::{InMemoryProjectionStore, ProjectionStoreError};
+pub use publisher::{InMemoryPublisher, PublisherError};
+pub use adaptor::{InMemoryAdaptor, AdaptorError};
+pub use dead_letter::{InMemoryDeadLetterStore, InMemoryDeadLetter, DeadLetterError};

--- a/canon-core/src/memory/projection_store.rs
+++ b/canon-core/src/memory/projection_store.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::{ProjectionStore, Version};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionStoreError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryProjectionStore {
+    inner: Arc<Mutex<HashMap<String, Version>>>,
+}
+
+impl ProjectionStore for InMemoryProjectionStore {}
+
+impl InMemoryProjectionStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Return the stored checkpoint version, or Version::initial() if not set.
+    pub fn get_checkpoint(
+        &self,
+        projection_id: &str,
+    ) -> Result<Version, ProjectionStoreError> {
+        let store = self.inner.lock().map_err(|_| ProjectionStoreError::Poisoned)?;
+        Ok(store
+            .get(projection_id)
+            .copied()
+            .unwrap_or_else(Version::initial))
+    }
+
+    /// Upsert the checkpoint version for a projection.
+    pub fn set_checkpoint(
+        &self,
+        projection_id: &str,
+        version: Version,
+    ) -> Result<(), ProjectionStoreError> {
+        let mut store = self.inner.lock().map_err(|_| ProjectionStoreError::Poisoned)?;
+        store.insert(projection_id.to_owned(), version);
+        Ok(())
+    }
+}
+
+impl Default for InMemoryProjectionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_checkpoint_is_initial() {
+        let store = InMemoryProjectionStore::new();
+        let v = store.get_checkpoint("proj-1").unwrap();
+        assert_eq!(v, Version::initial());
+    }
+
+    #[test]
+    fn set_and_get_checkpoint() {
+        let store = InMemoryProjectionStore::new();
+        let v = Version::initial().next().next().next();
+        store.set_checkpoint("proj-1", v).unwrap();
+        assert_eq!(store.get_checkpoint("proj-1").unwrap(), v);
+    }
+
+    #[test]
+    fn set_checkpoint_upserts() {
+        let store = InMemoryProjectionStore::new();
+        store
+            .set_checkpoint("proj-1", Version::initial().next())
+            .unwrap();
+        store
+            .set_checkpoint("proj-1", Version::initial().next().next())
+            .unwrap();
+        assert_eq!(
+            store.get_checkpoint("proj-1").unwrap().as_u64(),
+            2
+        );
+    }
+}

--- a/canon-core/src/memory/publisher.rs
+++ b/canon-core/src/memory/publisher.rs
@@ -1,0 +1,80 @@
+use std::sync::{Arc, Mutex};
+
+use crate::EventEnvelope;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PublisherError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryPublisher {
+    inner: Arc<Mutex<Vec<(EventEnvelope, String)>>>,
+}
+
+impl InMemoryPublisher {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Publish an event to a topic. Appends the (envelope, topic) pair.
+    pub fn publish(
+        &self,
+        envelope: EventEnvelope,
+        topic: &str,
+    ) -> Result<(), PublisherError> {
+        let mut store = self.inner.lock().map_err(|_| PublisherError::Poisoned)?;
+        store.push((envelope, topic.to_owned()));
+        Ok(())
+    }
+
+    /// Return a clone of all published events. Used for test assertions.
+    pub fn published_events(&self) -> Result<Vec<(EventEnvelope, String)>, PublisherError> {
+        let store = self.inner.lock().map_err(|_| PublisherError::Poisoned)?;
+        Ok(store.clone())
+    }
+}
+
+impl Default for InMemoryPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use uuid::Uuid;
+    use crate::{AggregateId, Version};
+
+    fn make_event() -> EventEnvelope {
+        EventEnvelope {
+            event_id: Uuid::new_v4(),
+            aggregate_id: AggregateId::new(),
+            version: Version::initial().next(),
+            event_type: "TestEvent".into(),
+            event_version: 1,
+            payload: Bytes::from_static(b"{}"),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn publish_and_read_back() {
+        let publisher = InMemoryPublisher::new();
+        publisher.publish(make_event(), "topic-a").unwrap();
+        publisher.publish(make_event(), "topic-b").unwrap();
+
+        let events = publisher.published_events().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].1, "topic-a");
+        assert_eq!(events[1].1, "topic-b");
+    }
+}

--- a/canon-core/src/memory/queue.rs
+++ b/canon-core/src/memory/queue.rs
@@ -1,0 +1,88 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::CommandEnvelope;
+
+#[derive(Debug, thiserror::Error)]
+pub enum QueueError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemoryQueue {
+    inner: Arc<Mutex<VecDeque<CommandEnvelope>>>,
+}
+
+impl InMemoryQueue {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Push a command onto the back of the queue.
+    pub fn publish(&self, envelope: CommandEnvelope) -> Result<(), QueueError> {
+        let mut queue = self.inner.lock().map_err(|_| QueueError::Poisoned)?;
+        queue.push_back(envelope);
+        Ok(())
+    }
+
+    /// Pop a command from the front of the queue, or None if empty.
+    pub fn receive(&self) -> Result<Option<CommandEnvelope>, QueueError> {
+        let mut queue = self.inner.lock().map_err(|_| QueueError::Poisoned)?;
+        Ok(queue.pop_front())
+    }
+
+    /// Acknowledge delivery — no-op in the in-memory impl.
+    pub fn ack(&self) -> Result<(), QueueError> {
+        Ok(())
+    }
+
+    /// Negative acknowledge — no-op in the in-memory impl.
+    pub fn nack(&self) -> Result<(), QueueError> {
+        Ok(())
+    }
+}
+
+impl Default for InMemoryQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use uuid::Uuid;
+    use crate::AggregateId;
+
+    fn make_command() -> CommandEnvelope {
+        CommandEnvelope {
+            command_id: Uuid::new_v4(),
+            aggregate_id: AggregateId::new(),
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            payload: Bytes::from_static(b"{}"),
+        }
+    }
+
+    #[test]
+    fn fifo_ordering() {
+        let queue = InMemoryQueue::new();
+        let cmd1 = make_command();
+        let cmd2 = make_command();
+        let id1 = cmd1.command_id;
+        let id2 = cmd2.command_id;
+
+        queue.publish(cmd1).unwrap();
+        queue.publish(cmd2).unwrap();
+
+        assert_eq!(queue.receive().unwrap().unwrap().command_id, id1);
+        assert_eq!(queue.receive().unwrap().unwrap().command_id, id2);
+        assert!(queue.receive().unwrap().is_none());
+    }
+}

--- a/canon-core/src/memory/snapshot_store.rs
+++ b/canon-core/src/memory/snapshot_store.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::{AggregateId, Snapshot};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotStoreError {
+    #[error("lock poisoned")]
+    Poisoned,
+}
+
+#[derive(Clone)]
+pub struct InMemorySnapshotStore {
+    inner: Arc<Mutex<HashMap<AggregateId, Snapshot>>>,
+}
+
+impl InMemorySnapshotStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Upsert — always replaces the existing snapshot for this aggregate.
+    pub fn save(&self, snapshot: Snapshot) -> Result<(), SnapshotStoreError> {
+        let mut store = self.inner.lock().map_err(|_| SnapshotStoreError::Poisoned)?;
+        store.insert(snapshot.aggregate_id.clone(), snapshot);
+        Ok(())
+    }
+
+    /// Load the latest snapshot for an aggregate, or None if none exists.
+    pub fn load(&self, aggregate_id: &AggregateId) -> Result<Option<Snapshot>, SnapshotStoreError> {
+        let store = self.inner.lock().map_err(|_| SnapshotStoreError::Poisoned)?;
+        Ok(store.get(aggregate_id).cloned())
+    }
+}
+
+impl Default for InMemorySnapshotStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use crate::Version;
+
+    #[test]
+    fn save_and_load() {
+        let store = InMemorySnapshotStore::new();
+        let id = AggregateId::new();
+        let snap = Snapshot {
+            aggregate_id: id.clone(),
+            version: Version::initial().next(),
+            state: Bytes::from_static(b"state"),
+            taken_at: Utc::now(),
+        };
+        store.save(snap).unwrap();
+
+        let loaded = store.load(&id).unwrap().unwrap();
+        assert_eq!(loaded.version.as_u64(), 1);
+    }
+
+    #[test]
+    fn save_upserts() {
+        let store = InMemorySnapshotStore::new();
+        let id = AggregateId::new();
+        let snap1 = Snapshot {
+            aggregate_id: id.clone(),
+            version: Version::initial().next(),
+            state: Bytes::from_static(b"v1"),
+            taken_at: Utc::now(),
+        };
+        let snap2 = Snapshot {
+            aggregate_id: id.clone(),
+            version: Version::initial().next().next(),
+            state: Bytes::from_static(b"v2"),
+            taken_at: Utc::now(),
+        };
+        store.save(snap1).unwrap();
+        store.save(snap2).unwrap();
+
+        let loaded = store.load(&id).unwrap().unwrap();
+        assert_eq!(loaded.version.as_u64(), 2);
+        assert_eq!(loaded.state.as_ref(), b"v2");
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let store = InMemorySnapshotStore::new();
+        let result = store.load(&AggregateId::new()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/canon-core/src/types.rs
+++ b/canon-core/src/types.rs
@@ -68,6 +68,32 @@ pub enum Oversight {
     Discard,    // abandon this accumulation window entirely
 }
 
+impl IncomingMessage {
+    pub fn message_id(&self) -> Uuid {
+        match self {
+            IncomingMessage::Command(c) => c.command_id,
+            IncomingMessage::InternalEvent(e) | IncomingMessage::ExternalEvent(e) => e.event_id,
+        }
+    }
+
+    pub fn aggregate_id(&self) -> &AggregateId {
+        match self {
+            IncomingMessage::Command(c) => &c.aggregate_id,
+            IncomingMessage::InternalEvent(e) | IncomingMessage::ExternalEvent(e) => &e.aggregate_id,
+        }
+    }
+}
+
+/// A point-in-time snapshot of aggregate state. Used to avoid replaying
+/// the full event history on every load.
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    pub aggregate_id: AggregateId,
+    pub version: Version,
+    pub state: Bytes,
+    pub taken_at: DateTime<Utc>,
+}
+
 // ── Counterfactual replay ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Closes #5

## Summary
- All nine in-memory implementations under `canon-core/src/memory/`:
  `InMemoryEventStore`, `InMemoryCommandStore`, `InMemorySnapshotStore`,
  `InMemoryInbox`, `InMemoryQueue`, `InMemoryProjectionStore`,
  `InMemoryPublisher`, `InMemoryAdaptor`, `InMemoryDeadLetterStore`
- All backed by `Arc<Mutex<...>>` — Clone + Send + Sync
- 25 unit tests covering key behaviours

## Key behaviours
- **InMemoryEventStore**: optimistic concurrency — rejects appends when `expected_version` doesn't match stored version
- **InMemoryInbox**: deduplicates by (handler_id, message_id), accumulates windows per (handler, aggregate), evaluates registered oversight function on each submit, dispatches on Ready, clears on Discard, holds on NotReady
- **InMemoryPublisher**: exposes `published_events()` for test assertions
- **InMemoryAdaptor**: exposes `inject()` for simulating external events, `subscribe()` returns a `futures::Stream`
- **InMemoryDeadLetterStore**: requeue sets flag, discard removes entry, both return `NotFound` error for missing IDs

## Changes to existing files
- **`types.rs`**: added `Snapshot` struct (needed by snapshot store), added `message_id()` and `aggregate_id()` helper methods on `IncomingMessage`
- **`lib.rs`**: added `pub mod memory` and re-exports for all impls + error types

## New dependencies in `canon-core/Cargo.toml`
- **`thiserror 1`** — error types for each impl, per CLAUDE.md rule: "thiserror in every crate"
- **`tokio 1` (dev-dependency only)** — used in adaptor tests to drive the futures::Stream returned by `subscribe()`

## Verification
- `cargo test -p canon-core` — 29 tests pass (25 new + 4 existing)
- `cargo clippy -p canon-core -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)