### PR TITLE
feat(canon-deadletter): implement trait crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "trybuild",
  "uuid",
@@ -116,7 +116,12 @@ dependencies = [
 name = "canon-deadletter"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "bytes",
  "canon-core",
+ "chrono",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -235,7 +240,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "trybuild",
  "uuid",
@@ -820,7 +825,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -828,6 +842,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/canon-deadletter/Cargo.toml
+++ b/canon-deadletter/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [dependencies]
 canon-core = { path = "../canon-core" }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }

--- a/canon-deadletter/README.md
+++ b/canon-deadletter/README.md
@@ -1,0 +1,88 @@
+# canon-deadletter
+
+Part of the [Canon](https://github.com/rjh-mopjones/canon) event sourcing framework.
+
+## Overview
+
+`canon-deadletter` defines the `DeadLetterStore` port — the trait that abstracts persisting and managing messages that have exhausted their retry budget. Failed messages are stored with their error context and can be inspected, requeued for reprocessing, or permanently discarded via an admin API. The infrastructure implementation is provided by `canon-deadletter-yugabyte`.
+
+## Trait
+
+```rust
+#[async_trait]
+pub trait DeadLetterStore: Send + Sync + 'static {
+    /// Persist a dead letter entry.
+    async fn store(&self, letter: DeadLetter) -> Result<(), DeadLetterError>;
+
+    /// List dead letters, optionally filtered by handler ID.
+    async fn list(&self, handler_id: Option<&str>) -> Result<Vec<DeadLetter>, DeadLetterError>;
+
+    /// Re-enter a dead letter into the inbox for reprocessing.
+    async fn requeue(&self, id: Uuid) -> Result<(), DeadLetterError>;
+
+    /// Permanently remove a dead letter.
+    async fn discard(&self, id: Uuid) -> Result<(), DeadLetterError>;
+}
+```
+
+## Error types
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DeadLetterError {
+    #[error("dead letter error: {0}")]
+    Store(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+```
+
+## Re-exports
+
+The following type is re-exported from `canon-core`:
+
+- `AggregateId` — newtype wrapper around `Uuid` identifying an aggregate instance
+
+## Usage
+
+A downstream infrastructure crate depends on this trait:
+
+```rust
+use canon_deadletter::{DeadLetterStore, DeadLetter, DeadLetterError, AggregateId};
+use async_trait::async_trait;
+
+pub struct YugabyteDeadLetterStore { /* ... */ }
+
+#[async_trait]
+impl DeadLetterStore for YugabyteDeadLetterStore {
+    async fn store(&self, letter: DeadLetter) -> Result<(), DeadLetterError> {
+        // Insert dead letter row into YugabyteDB
+        todo!()
+    }
+
+    async fn list(&self, handler_id: Option<&str>) -> Result<Vec<DeadLetter>, DeadLetterError> {
+        // Query dead letters from YugabyteDB
+        todo!()
+    }
+
+    async fn requeue(&self, id: uuid::Uuid) -> Result<(), DeadLetterError> {
+        // Re-enter message into inbox with fresh expires_at
+        todo!()
+    }
+
+    async fn discard(&self, id: uuid::Uuid) -> Result<(), DeadLetterError> {
+        // Delete dead letter row from YugabyteDB
+        todo!()
+    }
+}
+```
+
+## Dependencies
+
+```toml
+[dependencies]
+canon-core = { path = "../canon-core" }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+```

--- a/canon-deadletter/src/lib.rs
+++ b/canon-deadletter/src/lib.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+pub use canon_core::AggregateId;
+
+/// A message that has exhausted its retry budget and been moved to the dead letter store.
+#[derive(Debug, Clone)]
+pub struct DeadLetter {
+    pub id: Uuid,
+    pub message_id: Uuid,
+    pub handler_id: String,
+    pub aggregate_id: AggregateId,
+    pub payload: Bytes,
+    pub error: String,
+    pub attempts: u32,
+    pub created_at: DateTime<Utc>,
+    pub last_attempted: DateTime<Utc>,
+}
+
+/// Errors returned by [`DeadLetterStore`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DeadLetterError {
+    #[error("dead letter error: {0}")]
+    Store(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Port for persisting and managing dead-lettered messages.
+///
+/// Implementations are provided by infrastructure crates such as `canon-deadletter-yugabyte`.
+#[async_trait]
+pub trait DeadLetterStore: Send + Sync + 'static {
+    /// Persist a dead letter entry.
+    async fn store(&self, letter: DeadLetter) -> Result<(), DeadLetterError>;
+
+    /// List dead letters, optionally filtered by handler ID.
+    async fn list(&self, handler_id: Option<&str>) -> Result<Vec<DeadLetter>, DeadLetterError>;
+
+    /// Re-enter a dead letter into the inbox for reprocessing.
+    async fn requeue(&self, id: Uuid) -> Result<(), DeadLetterError>;
+
+    /// Permanently remove a dead letter.
+    async fn discard(&self, id: Uuid) -> Result<(), DeadLetterError>;
+}


### PR DESCRIPTION
Closes #15

## Summary
- Define `DeadLetterStore` trait with `store`, `list`, `requeue`, and `discard` methods
- Add `DeadLetter` struct and `DeadLetterError` error enum
- Re-export `AggregateId` from `canon-core`
- Add README with trait docs, error types, re-exports, usage example, and dependencies

## Checklist
- [x] `cargo check -p canon-deadletter` passes with zero warnings
- [x] `canon-deadletter/README.md` exists with all required sections
- [x] No `unwrap()` or `expect()` in source
- [x] No TODO comments
- [x] No infrastructure dependencies
- [x] `async_trait` on trait, `thiserror` for errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)