### PR TITLE
feat(canon-adaptor): implement trait crate

### DIFF
--- a/canon-snapshot-store/Cargo.toml
+++ b/canon-snapshot-store/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [dependencies]
 canon-core = { path = "../canon-core" }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }

--- a/canon-snapshot-store/src/lib.rs
+++ b/canon-snapshot-store/src/lib.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+
+pub use canon_core::{AggregateId, Version};
+
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    pub aggregate_id: AggregateId,
+    pub version: Version,
+    pub state: Bytes,
+    pub taken_at: DateTime<Utc>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotStoreError {
+    #[error("store error: {0}")]
+    Store(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[async_trait]
+pub trait SnapshotStore: Send + Sync + 'static {
+    /// Upsert — always overwrites any existing snapshot for this aggregate.
+    async fn save(&self, snapshot: Snapshot) -> Result<(), SnapshotStoreError>;
+
+    /// Return the most recent snapshot, or None if none exists.
+    async fn load(&self, aggregate_id: &AggregateId) -> Result<Option<Snapshot>, SnapshotStoreError>;
+}


### PR DESCRIPTION
Closes #14

Thin trait crate. Trait definition, error type, and canon-core re-exports only.