### PR TITLE
fix(ci): install libcurl-dev for rdkafka-sys compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy


### PR DESCRIPTION
## Summary
- Adds `libcurl4-openssl-dev` system dependency to CI workflow
- Required for `rdkafka-sys` to compile `librdkafka` statically (needs `curl/curl.h`)
- Fixes build failures on all Kafka-dependent PRs (#70, #71, #74)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, rebase Kafka PRs and verify they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)