### PR TITLE
Add Claude Code project settings and hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.rs) rustfmt --edition 2021 \"$f\" ;; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | grep -qE '(CLAUDE\\.md$|Cargo\\.lock$|\\.git/)' && echo '{\"decision\":\"block\",\"reason\":\"Protected file\"}' || true"
+          }
+        ]
+      }
+    ]
+  },
+  "env": {
+    "RUST_BACKTRACE": "1",
+    "CARGO_TERM_COLOR": "always"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with project-level hooks and env vars:
  - **PostToolUse**: auto-format `.rs` files with `rustfmt` after every edit/write
  - **PreToolUse**: block edits to `CLAUDE.md`, `Cargo.lock`, and `.git/`
  - **Environment**: `RUST_BACKTRACE=1`, `CARGO_TERM_COLOR=always`
- Add `.claude/settings.local.json` to `.gitignore` so personal overrides stay local

## What's NOT in the PR (applied locally only)
- `~/.claude/settings.json`: desktop notifications on idle, PreCompact context injection
- `.claude/settings.local.json`: expanded cargo/gh permissions

## Test plan
- [ ] `jq . .claude/settings.json` validates without error
- [ ] Edit a `.rs` file — rustfmt hook fires and formats it
- [ ] Try editing `CLAUDE.md` — PreToolUse hook blocks it
- [ ] Verify `.claude/settings.local.json` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)