### PR TITLE
fix(core): add Version::from_u64

### DIFF
--- a/canon-core/src/types.rs
+++ b/canon-core/src/types.rs
@@ -23,6 +23,7 @@ impl Version {
     pub fn initial() -> Self { Self(0) }
     pub fn next(self) -> Self { Self(self.0 + 1) }
     pub fn as_u64(&self) -> u64 { self.0 }
+    pub fn from_u64(v: u64) -> Self { Self(v) }
 }
 
 /// Every event written to the store is wrapped in this envelope.


### PR DESCRIPTION
## Summary
- Adds `Version::from_u64(v: u64) -> Self` constructor to `canon-core`

## Context
Prerequisite for PRs #68, #69, #72, #73, #74. Infrastructure crates need to construct `Version` from database `i64`/`u64` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)