### PR TITLE
feat(shared): add canon-demo shared domain types, events, commands, and topic constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,8 @@ name = "canon-demo-shared"
 version = "0.1.0"
 dependencies = [
  "canon-core",
+ "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/canon-demo/shared/Cargo.toml
+++ b/canon-demo/shared/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 canon-core = { path = "../../canon-core" }
+uuid = { version = "1", features = ["v4", "serde"] }
+serde = { version = "1", features = ["derive"] }

--- a/canon-demo/shared/src/commands.rs
+++ b/canon-demo/shared/src/commands.rs
@@ -1,0 +1,153 @@
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fleet commands (aggregate: Ship)
+// ---------------------------------------------------------------------------
+
+#[canon_core::command(Ship, version = 1, produces = [ShipRegistered])]
+pub struct RegisterShip {
+    pub name: String,
+    pub capacity_kg: f32,
+}
+
+#[canon_core::command(Ship, version = 1, produces = [RouteAssigned])]
+pub struct AssignRoute {
+    pub ship_id: Uuid,
+    pub route_id: Uuid,
+}
+
+#[canon_core::command(Ship, version = 1, produces = [ShipDeparted])]
+pub struct DepartForStation {
+    pub ship_id: Uuid,
+    pub destination_station_id: Uuid,
+}
+
+#[canon_core::command(Ship, version = 1, produces = [ResupplyScheduled])]
+pub struct ScheduleResupply {
+    pub ship_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::command(Ship, version = 1, produces = [ShipDecommissioned])]
+pub struct DecommissionShip {
+    pub ship_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Cargo commands (aggregate: Manifest)
+// ---------------------------------------------------------------------------
+
+#[canon_core::command(Manifest, version = 1, produces = [ManifestCreated])]
+pub struct CreateManifest {
+    pub ship_id: Uuid,
+    pub voyage_id: Uuid,
+}
+
+#[canon_core::command(Manifest, version = 1, produces = [CargoLoaded])]
+pub struct LoadCargo {
+    pub manifest_id: Uuid,
+    pub item_id: Uuid,
+    pub weight_kg: f32,
+    pub description: String,
+}
+
+#[canon_core::command(Manifest, version = 1, produces = [UnloadingStarted])]
+pub struct BeginUnloading {
+    pub manifest_id: Uuid,
+    pub station_id: Uuid,
+}
+
+#[canon_core::command(Manifest, version = 1, produces = [CargoUnloaded])]
+pub struct RecordUnloaded {
+    pub manifest_id: Uuid,
+    pub item_id: Uuid,
+}
+
+#[canon_core::command(Manifest, version = 1, produces = [ManifestClosed])]
+pub struct CloseManifest {
+    pub manifest_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Navigation commands (aggregate: Route)
+// ---------------------------------------------------------------------------
+
+#[canon_core::command(Route, version = 1, produces = [RoutePlanned])]
+pub struct PlanRoute {
+    pub ship_id: Uuid,
+    pub waypoints: Vec<Uuid>,
+}
+
+#[canon_core::command(Route, version = 1)]
+pub struct RecordDeparture {
+    pub route_id: Uuid,
+    pub ship_id: Uuid,
+}
+
+#[canon_core::command(Route, version = 1, produces = [PositionUpdated])]
+pub struct UpdatePosition {
+    pub route_id: Uuid,
+    pub waypoint_id: Uuid,
+}
+
+#[canon_core::command(Route, version = 1, produces = [ShipArrivedAtStation])]
+pub struct RecordArrival {
+    pub route_id: Uuid,
+    pub station_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Supply commands (aggregate: Inventory)
+// ---------------------------------------------------------------------------
+
+#[canon_core::command(Inventory, version = 1, produces = [StockRecorded])]
+pub struct RecordStock {
+    pub station_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::command(Inventory, version = 1, produces = [ResupplyRequested])]
+pub struct RequestResupply {
+    pub station_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::command(Inventory, version = 1, produces = [ResupplyDispatched])]
+pub struct DispatchResupply {
+    pub inventory_id: Uuid,
+    pub ship_id: Uuid,
+}
+
+#[canon_core::command(Inventory, version = 1, produces = [DeliveryConfirmed])]
+pub struct ConfirmDelivery {
+    pub inventory_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Station commands (aggregate: Station)
+// ---------------------------------------------------------------------------
+
+#[canon_core::command(Station, version = 1, produces = [StationRegistered])]
+pub struct RegisterStation {
+    pub name: String,
+    pub capacity_kg: f32,
+}
+
+#[canon_core::command(Station, version = 1, produces = [ShipDocked])]
+pub struct RecordDocking {
+    pub station_id: Uuid,
+    pub ship_id: Uuid,
+}
+
+#[canon_core::command(Station, version = 1, produces = [CargoReceived])]
+pub struct RecordCargoReceived {
+    pub station_id: Uuid,
+    pub manifest_id: Uuid,
+    pub weight_kg: f32,
+}
+
+#[canon_core::command(Station, version = 1, produces = [CapacityUpdated])]
+pub struct UpdateCapacity {
+    pub station_id: Uuid,
+    pub capacity_kg: f32,
+}

--- a/canon-demo/shared/src/events.rs
+++ b/canon-demo/shared/src/events.rs
@@ -1,0 +1,226 @@
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Fleet events (aggregate: Ship)
+// ---------------------------------------------------------------------------
+
+#[canon_core::event(Ship, version = 1)]
+pub struct ShipRegistered {
+    pub ship_id: Uuid,
+    pub name: String,
+    pub capacity_kg: f32,
+}
+
+#[canon_core::event(Ship, version = 1)]
+pub struct RouteAssigned {
+    pub ship_id: Uuid,
+    pub route_id: Uuid,
+}
+
+#[canon_core::event(Ship, version = 1)]
+pub struct ShipDeparted {
+    pub ship_id: Uuid,
+    pub station_id: Uuid,
+    pub destination_id: Uuid,
+}
+
+#[canon_core::event(Ship, version = 1)]
+pub struct ResupplyScheduled {
+    pub ship_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::event(Ship, version = 1)]
+pub struct ShipDecommissioned {
+    pub ship_id: Uuid,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum FleetEvent {
+    ShipRegistered(ShipRegistered),
+    RouteAssigned(RouteAssigned),
+    ShipDeparted(ShipDeparted),
+    ResupplyScheduled(ResupplyScheduled),
+    ShipDecommissioned(ShipDecommissioned),
+}
+
+// ---------------------------------------------------------------------------
+// Cargo events (aggregate: Manifest)
+// ---------------------------------------------------------------------------
+
+#[canon_core::event(Manifest, version = 1)]
+pub struct ManifestCreated {
+    pub manifest_id: Uuid,
+    pub ship_id: Uuid,
+    pub voyage_id: Uuid,
+}
+
+#[canon_core::event(Manifest, version = 2)]
+pub struct CargoLoaded {
+    pub manifest_id: Uuid,
+    pub item_id: Uuid,
+    pub weight_kg: f32,
+    pub description: String,
+}
+
+#[canon_core::event(Manifest, version = 1)]
+pub struct UnloadingStarted {
+    pub manifest_id: Uuid,
+    pub station_id: Uuid,
+}
+
+#[canon_core::event(Manifest, version = 1)]
+pub struct CargoUnloaded {
+    pub manifest_id: Uuid,
+    pub item_id: Uuid,
+}
+
+#[canon_core::event(Manifest, version = 1)]
+pub struct ManifestClosed {
+    pub manifest_id: Uuid,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum CargoEvent {
+    ManifestCreated(ManifestCreated),
+    CargoLoaded(CargoLoaded),
+    UnloadingStarted(UnloadingStarted),
+    CargoUnloaded(CargoUnloaded),
+    ManifestClosed(ManifestClosed),
+}
+
+// ---------------------------------------------------------------------------
+// Navigation events (aggregate: Route)
+// ---------------------------------------------------------------------------
+
+#[canon_core::event(Route, version = 1)]
+pub struct RoutePlanned {
+    pub route_id: Uuid,
+    pub ship_id: Uuid,
+    pub waypoints: Vec<Uuid>,
+}
+
+#[canon_core::event(Route, version = 1)]
+pub struct PositionUpdated {
+    pub route_id: Uuid,
+    pub ship_id: Uuid,
+    pub waypoint_id: Uuid,
+}
+
+#[canon_core::event(Route, version = 1)]
+pub struct ShipArrivedAtStation {
+    pub route_id: Uuid,
+    pub ship_id: Uuid,
+    pub station_id: Uuid,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum NavigationEvent {
+    RoutePlanned(RoutePlanned),
+    PositionUpdated(PositionUpdated),
+    ShipArrivedAtStation(ShipArrivedAtStation),
+}
+
+// ---------------------------------------------------------------------------
+// Supply events (aggregate: Inventory)
+// ---------------------------------------------------------------------------
+
+#[canon_core::event(Inventory, version = 1)]
+pub struct StockRecorded {
+    pub inventory_id: Uuid,
+    pub station_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::event(Inventory, version = 1)]
+pub struct ResupplyRequested {
+    pub inventory_id: Uuid,
+    pub station_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::event(Inventory, version = 1)]
+pub struct ResupplyDispatched {
+    pub inventory_id: Uuid,
+    pub ship_id: Uuid,
+    pub fuel_kg: f32,
+}
+
+#[canon_core::event(Inventory, version = 1)]
+pub struct DeliveryConfirmed {
+    pub inventory_id: Uuid,
+    pub ship_id: Uuid,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum SupplyEvent {
+    StockRecorded(StockRecorded),
+    ResupplyRequested(ResupplyRequested),
+    ResupplyDispatched(ResupplyDispatched),
+    DeliveryConfirmed(DeliveryConfirmed),
+}
+
+// ---------------------------------------------------------------------------
+// Station events (aggregate: Station)
+// ---------------------------------------------------------------------------
+
+#[canon_core::event(Station, version = 1)]
+pub struct StationRegistered {
+    pub station_id: Uuid,
+    pub name: String,
+    pub capacity_kg: f32,
+}
+
+#[canon_core::event(Station, version = 1)]
+pub struct ShipDocked {
+    pub station_id: Uuid,
+    pub ship_id: Uuid,
+}
+
+#[canon_core::event(Station, version = 1)]
+pub struct CargoReceived {
+    pub station_id: Uuid,
+    pub manifest_id: Uuid,
+    pub weight_kg: f32,
+}
+
+#[canon_core::event(Station, version = 1)]
+pub struct StationStockLow {
+    pub station_id: Uuid,
+    pub current_fuel_kg: f32,
+    pub threshold_kg: f32,
+}
+
+#[canon_core::event(Station, version = 1)]
+pub struct CapacityUpdated {
+    pub station_id: Uuid,
+    pub capacity_kg: f32,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum StationEvent {
+    StationRegistered(StationRegistered),
+    ShipDocked(ShipDocked),
+    CargoReceived(CargoReceived),
+    StationStockLow(StationStockLow),
+    CapacityUpdated(CapacityUpdated),
+}
+
+// ---------------------------------------------------------------------------
+// Top-level demo event
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "domain")]
+pub enum DemoEvent {
+    Fleet(FleetEvent),
+    Cargo(CargoEvent),
+    Navigation(NavigationEvent),
+    Supply(SupplyEvent),
+    Station(StationEvent),
+}

--- a/canon-demo/shared/src/lib.rs
+++ b/canon-demo/shared/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod commands;
+pub mod events;
+pub mod topics;

--- a/canon-demo/shared/src/topics.rs
+++ b/canon-demo/shared/src/topics.rs
@@ -1,0 +1,5 @@
+pub const FLEET_EVENTS: &str = "canon.fleet.events";
+pub const CARGO_EVENTS: &str = "canon.cargo.events";
+pub const NAVIGATION_EVENTS: &str = "canon.navigation.events";
+pub const SUPPLY_EVENTS: &str = "canon.supply.events";
+pub const STATION_EVENTS: &str = "canon.station.events";


### PR DESCRIPTION
## Summary
Implements `canon-demo/shared` — the single source of truth for the demo domain vocabulary. All 5 domains (fleet, cargo, navigation, supply, station) get event structs, command structs, domain enums, and Kafka topic constants. Zero logic — types and constants only.

## Changes
- `shared/src/topics.rs`: 5 Kafka topic constants (`canon.fleet.events`, etc.)
- `shared/src/events.rs`: 25 event structs with `#[event(Aggregate, version = N)]` macros across all 5 domains, plus 5 domain enums (`FleetEvent`, `CargoEvent`, etc.) with `#[serde(tag = "type")]`, plus top-level `DemoEvent` with `#[serde(tag = "domain")]`
- `shared/src/commands.rs`: 20 command structs with `#[command(Aggregate, version = N, produces = [...])]` macros across all 5 domains
- `shared/Cargo.toml`: added `uuid` and `serde` dependencies

## Testing
- `cargo check -p canon-demo-shared` passes
- `cargo check --workspace` passes
- `cargo test --workspace` passes (all 80+ tests green)
- `cargo clippy --workspace -- -D warnings` passes
- `cargo fmt -p canon-demo-shared -- --check` passes

## Assumptions
- `CargoLoaded` is defined at version 2 only (with `description` field), per the issue spec's "(v2 — has description)" note. V1 without description is not defined.
- `RecordDeparture` (navigation) omits the `produces` declaration — the issue does not list a corresponding navigation departure event, and `ShipDeparted` already belongs to Fleet. The service implementation phase will resolve which event this command produces.
- Navigation events exclude `ShipDeparted` (per issue body) to avoid naming conflict with Fleet's `ShipDeparted`. Navigation receives Fleet's departure via cross-service flow.

Closes #25