### PR TITLE
fix(shared): align ShipDeparted fields to CLAUDE.md and add README

### DIFF
--- a/canon-demo/shared/README.md
+++ b/canon-demo/shared/README.md
@@ -1,0 +1,27 @@
+# canon-demo-shared
+
+Shared domain types, events, commands, and Kafka topic constants for the Canon demo services. This crate is the single source of truth for the demo domain vocabulary. It contains zero logic -- types and constants only.
+
+## Modules
+
+| Module | Contents |
+|--------|----------|
+| `events` | 25 event structs across 5 domains with `#[event]` macros, plus domain enum wrappers (`FleetEvent`, `CargoEvent`, etc.) and top-level `DemoEvent` |
+| `commands` | 20 command structs across 5 domains with `#[command]` macros |
+| `topics` | Kafka topic constants (`canon.fleet.events`, `canon.cargo.events`, etc.) |
+
+## Domains
+
+| Service | Aggregate | Commands | Events |
+|---------|-----------|----------|--------|
+| fleet | Ship | RegisterShip, AssignRoute, DepartForStation, ScheduleResupply, DecommissionShip | ShipRegistered, RouteAssigned, ShipDeparted, ResupplyScheduled, ShipDecommissioned |
+| cargo | Manifest | CreateManifest, LoadCargo, BeginUnloading, RecordUnloaded, CloseManifest | ManifestCreated, CargoLoaded, UnloadingStarted, CargoUnloaded, ManifestClosed |
+| navigation | Route | PlanRoute, RecordDeparture, UpdatePosition, RecordArrival | RoutePlanned, PositionUpdated, ShipArrivedAtStation |
+| supply | Inventory | RecordStock, RequestResupply, DispatchResupply, ConfirmDelivery | StockRecorded, ResupplyRequested, ResupplyDispatched, DeliveryConfirmed |
+| station | Station | RegisterStation, RecordDocking, RecordCargoReceived, UpdateCapacity | StationRegistered, ShipDocked, CargoReceived, StationStockLow, CapacityUpdated |
+
+## Dependencies
+
+- `canon-core` -- proc-macros (`#[event]`, `#[command]`) and re-exported serde derives
+- `uuid` -- identity fields
+- `serde` -- serialization for domain enums

--- a/canon-demo/shared/src/commands.rs
+++ b/canon-demo/shared/src/commands.rs
@@ -19,7 +19,7 @@ pub struct AssignRoute {
 #[canon_core::command(Ship, version = 1, produces = [ShipDeparted])]
 pub struct DepartForStation {
     pub ship_id: Uuid,
-    pub destination_station_id: Uuid,
+    pub destination: Uuid,
 }
 
 #[canon_core::command(Ship, version = 1, produces = [ResupplyScheduled])]

--- a/canon-demo/shared/src/events.rs
+++ b/canon-demo/shared/src/events.rs
@@ -20,8 +20,8 @@ pub struct RouteAssigned {
 #[canon_core::event(Ship, version = 1)]
 pub struct ShipDeparted {
     pub ship_id: Uuid,
-    pub station_id: Uuid,
-    pub destination_id: Uuid,
+    pub destination: Uuid,
+    pub fuel_at_departure: f32,
 }
 
 #[canon_core::event(Ship, version = 1)]


### PR DESCRIPTION
## Summary
Cherry-picks the review fixes from PR #79 that were pushed after the PR was accidentally merged. These fixes were identified by the `/review-prs` bot.

## Changes
- `events.rs`: `ShipDeparted` fields changed from `{station_id, destination_id}` to `{destination, fuel_at_departure}` to match the CLAUDE.md spec
- `commands.rs`: `DepartForStation` field changed from `destination_station_id` to `destination`
- Added `README.md` for the shared crate (required by CLAUDE.md)

## Testing
- `cargo check -p canon-demo-shared` passes