### PR TITLE
fix(commands): make fix-prs sequential with merge prompts

### DIFF
--- a/.claude/commands/fix-prs.md
+++ b/.claude/commands/fix-prs.md
@@ -1,7 +1,8 @@
-# fix-prs — Canon PR conflict and CI failure fixer
+# fix-prs — Canon PR conflict and CI failure fixer (sequential)
 
 You are the Canon PR health agent. You will check every open PR for merge conflicts
-and CI failures, fix them all, and push clean branches.
+and CI failures, then fix them **one at a time** — fixing a PR, prompting the user to
+merge it, waiting for confirmation, then moving to the next.
 
 Read `CLAUDE.md` before doing anything else:
 ```bash
@@ -138,51 +139,30 @@ Classify every CI failure into one of these known Canon patterns:
 | **MISSING_MEMBER** | `error: no such package` | Add crate to workspace `Cargo.toml` |
 | **LOCK_CONFLICT** | `Cargo.lock ... conflicts` | Regenerate `Cargo.lock` |
 
-Save the classified failures:
+---
 
-```bash
-python3 << 'EOF'
-import json
+## Phase 2 — Fix PRs sequentially, one at a time
 
-# Load prs_to_fix and annotate with classified failure types
-# (you will fill this in as you read the failure output above)
-# Write /tmp/pr_failures.json with structure:
-# { "number": N, "failures": [{"type": "COMPILE_ERROR", "crate": "...", "detail": "..."}] }
-EOF
+**CRITICAL: Do NOT fix PRs in parallel.** Fix one PR, push, prompt the user to merge,
+wait for confirmation, fetch the updated main, then move to the next PR. This prevents
+cascade conflicts where merging one PR invalidates the fixes on others.
+
+Load the list of PRs to fix from `/tmp/prs_to_fix.json`. Process them in order.
+
+### For each PR, do the following:
+
+#### Step 1 — Announce which PR you are fixing
+
+Print clearly:
+```
+═══════════════════════════════════════════════════
+  Fixing PR #N of M: #{number} — {title}
+  Branch: {branch}
+  Problems: {problems}
+═══════════════════════════════════════════════════
 ```
 
----
-
-## Phase 2 — Fix conflicts and CI failures (parallel agents, one per PR)
-
-Spawn one agent per PR in `/tmp/prs_to_fix.json`. All agents run concurrently.
-
-```bash
-python3 << 'ORCHESTRATOR'
-import json, subprocess, os
-
-prs    = json.load(open('/tmp/prs_to_fix.json'))
-main   = subprocess.run(['git', 'rev-parse', 'origin/main'],
-                        capture_output=True, text=True).stdout.strip()
-
-AGENT_PROMPT = """
-You are the Canon PR fix agent for PR #{number} — "{title}".
-Branch: {branch}
-Current HEAD: {sha}
-Problems: {problems}
-
-Your job: fix every problem, push a clean branch, and report what you did.
-
-**IMPORTANT:** Use the LSP tool (rust-analyzer) throughout. After every code fix:
-- Use `LSP hover` on changed symbols to verify their types
-- Use `LSP goToDefinition` to confirm method/trait references resolve correctly
-- Use `LSP documentSymbol` on edited files to verify structure
-- Use `LSP findReferences` when renaming or removing items to catch all usages
-Never guess at type signatures or method existence — ask the LSP first.
-
----
-
-## Setup
+#### Step 2 — Fetch latest main and checkout the branch
 
 ```bash
 git fetch origin
@@ -190,9 +170,7 @@ git checkout {branch}
 git status
 ```
 
----
-
-## Step 1 — Fix merge conflicts
+#### Step 3 — Fix merge conflicts
 
 Check for conflicts against main:
 ```bash
@@ -207,7 +185,7 @@ git rebase origin/main
 
 **If the rebase hits conflicts, resolve them file by file using these rules:**
 
-### Cargo.toml conflicts (workspace members)
+##### Cargo.toml conflicts (workspace members)
 The `members` array in the root `Cargo.toml` is the most common conflict.
 Both sides added different crates — the correct resolution is ALWAYS to include
 ALL entries from both sides, in alphabetical order within each logical group.
@@ -227,14 +205,14 @@ Resolve to include both:
     "canon-snapshot-store-yugabyte",
 ```
 
-### Cargo.lock conflicts
+##### Cargo.lock conflicts
 Never manually resolve Cargo.lock conflicts. After resolving Cargo.toml:
 ```bash
 rm Cargo.lock
 cargo generate-lockfile 2>&1 | tail -5
 ```
 
-### ci.yml conflicts
+##### ci.yml conflicts
 The canonical ci.yml includes the `libcurl4-openssl-dev` system dependency install.
 If one side has it and the other doesn't, keep the version that has it:
 
@@ -254,18 +232,18 @@ jobs:
       - run: cargo test --workspace
 ```
 
-### canon-core/src/types.rs conflicts
+##### canon-core/src/types.rs conflicts
 If both sides add `Version::from_u64`, keep exactly one copy:
 ```rust
 pub fn from_u64(v: u64) -> Self {{ Self(v) }}
 ```
 Remove the duplicate, keep one.
 
-### README.md / CLAUDE.md conflicts
+##### README.md / CLAUDE.md conflicts
 These are documentation files. Read both sides, merge the content manually —
 keep all new sections from both sides. Never drop content added by either side.
 
-### After resolving each conflict file:
+##### After resolving each conflict file:
 ```bash
 git add <resolved-file>
 ```
@@ -282,9 +260,7 @@ git merge origin/main -m "merge: sync with main for PR #{number}"
 # Then resolve conflicts as above
 ```
 
----
-
-## Step 2 — Fix CI failures
+#### Step 4 — Fix CI failures
 
 After the conflict resolution, check what actually fails:
 
@@ -294,7 +270,7 @@ cargo check --workspace 2>&1 | grep -E "^error" | head -30
 
 Work through each class of failure:
 
-### COMPILE_ERROR — fix the Rust error
+##### COMPILE_ERROR — fix the Rust error
 
 Read the full error:
 ```bash
@@ -318,7 +294,7 @@ Common Canon compile errors:
 
 After each fix: `cargo check -p <crate>` to verify before moving on.
 
-### CLIPPY — fix the lint
+##### CLIPPY — fix the lint
 
 ```bash
 cargo clippy --workspace 2>&1 | grep "^error" | head -20
@@ -332,7 +308,7 @@ Common Canon clippy issues:
 
 After fixes: `cargo clippy --workspace -- -D warnings 2>&1 | grep "^error"`
 
-### TEST_FAIL — fix the failing test
+##### TEST_FAIL — fix the failing test
 
 ```bash
 cargo test --workspace 2>&1 | grep -A 20 "FAILED\\|failures:"
@@ -341,7 +317,7 @@ cargo test --workspace 2>&1 | grep -A 20 "FAILED\\|failures:"
 Read the test, understand why it fails, fix either the implementation or the test.
 Never delete a test to make CI pass.
 
-### MISSING_DEP — fix the system dependency
+##### MISSING_DEP — fix the system dependency
 
 If the failure is a linker error for `libssl`, `libcurl`, or `libsasl`:
 ```bash
@@ -349,16 +325,9 @@ If the failure is a linker error for `libssl`, `libcurl`, or `libsasl`:
 cat .github/workflows/ci.yml
 ```
 
-If the install step is missing, add it:
-```bash
-# Edit .github/workflows/ci.yml to add:
-#   - name: Install system dependencies
-#     run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-```
+If the install step is missing, add it.
 
----
-
-## Step 3 — Final verification
+#### Step 5 — Final verification
 
 **Use the LSP for final validation:** Run `LSP documentSymbol` on every file you
 changed to verify the structure is correct. Use `LSP hover` on any symbol you're
@@ -376,41 +345,18 @@ cargo clippy --workspace -- -D warnings 2>&1 | grep "^error" | wc -l
 cargo test --workspace 2>&1 | tail -10
 ```
 
-If anything still fails, iterate on Step 2 until clean.
+If anything still fails, iterate on Step 4 until clean.
 
----
-
-## Step 4 — Commit and push
+#### Step 6 — Commit and push
 
 ```bash
 git add -A
-
-# Build a descriptive commit message
-FIXES=""
-if git diff HEAD~ --name-only 2>/dev/null | grep -q "Cargo.toml"; then
-  FIXES="$FIXES\\n- resolve Cargo.toml workspace member conflicts"
-fi
-if git diff HEAD~ --name-only 2>/dev/null | grep -q "ci.yml"; then
-  FIXES="$FIXES\\n- fix ci.yml system dependency install"
-fi
-if git diff HEAD~ --name-only 2>/dev/null | grep -q "types.rs"; then
-  FIXES="$FIXES\\n- deduplicate Version::from_u64 in canon-core"
-fi
-
-git commit -m "fix: resolve conflicts and CI failures for PR #{number}
-
-$(echo -e $FIXES)
-
-Branch synced with main at $(git rev-parse --short origin/main)."
-
+git commit -m "fix: resolve conflicts and CI failures for PR #{number}"
 git push --force-with-lease origin {branch}
 ```
 
----
+#### Step 7 — Post a comment on the PR
 
-## Step 5 — Report
-
-Post a comment on the PR:
 ```bash
 FIX_SHA=$(git rev-parse HEAD)
 gh pr comment {number} --body "## fix-prs bot
@@ -420,106 +366,64 @@ Branch has been rebased onto main and all CI failures resolved.
 **Changes made:**
 $(git log --oneline HEAD~1..HEAD)
 
-**CI status before fix:** {problems}
-
 **Commit:** \`$FIX_SHA\`
 
 _Run \`/review-prs\` to re-review code quality after this sync._"
 ```
 
-Print: "PR #{number} done — $FIX_SHA"
-"""
+#### Step 8 — Prompt user to merge
 
-for pr in prs:
-    problems_parts = []
-    if pr['has_conflict']:
-        problems_parts.append('MERGE CONFLICT')
-    if pr['failing_checks']:
-        problems_parts.append('CI FAILURES: ' + ', '.join(pr['failing_checks']))
-    problems = ' | '.join(problems_parts) or 'unknown'
+**Print this clearly and then STOP and WAIT for the user to respond:**
 
-    prompt = AGENT_PROMPT.format(
-        number=pr['number'],
-        title=pr['title'],
-        branch=pr['branch'],
-        sha=pr['sha'],
-        problems=problems,
-    )
-
-    log_file = f"/tmp/fix_agent_pr{pr['number']}.log"
-    proc = subprocess.Popen(
-        ['claude', '--print', '--dangerously-skip-permissions'],
-        stdin=subprocess.PIPE,
-        stdout=open(log_file, 'w'),
-        stderr=subprocess.STDOUT,
-        text=True
-    )
-    proc.stdin.write(prompt)
-    proc.stdin.close()
-    print(f"Spawned fix agent for PR #{pr['number']} ({pr['branch']}) → {log_file}")
-
-print(f"\nAll {len(prs)} agents running...")
-ORCHESTRATOR
-
-wait
-echo "All fix agents finished."
 ```
+═══════════════════════════════════════════════════
+  ✓ PR #{number} is fixed and pushed.
+
+  → Please merge PR #{number} now: https://github.com/{owner}/{repo}/pull/{number}
+
+  Type "merged" or "done" when you have merged it,
+  or "skip" to move to the next PR without merging.
+
+  Remaining: {remaining_count} PRs after this one.
+═══════════════════════════════════════════════════
+```
+
+**Do NOT continue to the next PR until the user responds.** Use the AskUserQuestion
+tool if needed. This is the critical difference from the old parallel approach — we
+must wait for the merge so that the next PR rebases onto the updated main.
+
+#### Step 9 — After user confirms merge (or skip)
+
+If the user confirmed merge:
+```bash
+git fetch origin main
+git checkout main
+git pull origin main
+```
+
+Then move to the next PR in the list and repeat from Step 1.
+
+If the user said "skip": move to the next PR without fetching main (it hasn't changed).
 
 ---
 
-## Phase 3 — Verify and report
+## Phase 3 — Summary
 
-```bash
-python3 << 'EOF'
-import json, subprocess, os
+After all PRs have been processed, print a summary:
 
-prs = json.load(open('/tmp/prs_to_fix.json'))
+```
+═══════════════════════════════════════════════════
+  FIX-PRS COMPLETE
+═══════════════════════════════════════════════════
 
-print("=" * 60)
-print("FIX-PRS SUMMARY")
-print("=" * 60)
+  Fixed and merged:  N PRs
+  Skipped:           N PRs
 
-all_ok = True
-for pr in prs:
-    num = pr['number']
-    log = f"/tmp/fix_agent_pr{num}.log"
-    print(f"\nPR #{num}: {pr['title']}")
+  PR #X — {title} — merged ✓
+  PR #Y — {title} — merged ✓
+  PR #Z — {title} — skipped
 
-    if not os.path.exists(log):
-        print("  ERROR: no log found")
-        all_ok = False
-        continue
-
-    content = open(log).read()
-    lines = content.strip().split('\n')
-
-    # Find the final status line
-    done_lines = [l for l in lines if f'PR #{num} done' in l or 'error' in l.lower()]
-    for l in done_lines[-3:]:
-        print(f"  {l}")
-
-    # Check CI status of the updated branch
-    result = subprocess.run(
-        ['gh', 'pr', 'view', str(num), '--json', 'mergeStateStatus,statusCheckRollup'],
-        capture_output=True, text=True
-    )
-    if result.stdout.strip():
-        try:
-            data = json.loads(result.stdout)
-            state = data.get('mergeStateStatus', '?')
-            checks = data.get('statusCheckRollup') or []
-            failing = [c for c in checks if c.get('conclusion') in ('FAILURE', 'ERROR')]
-            print(f"  Merge state: {state} | Failing checks: {len(failing)}")
-        except:
-            pass
-
-print("\n" + "=" * 60)
-if all_ok:
-    print("All fix agents completed. Check GitHub for updated CI status.")
-    print("Note: CI takes ~2-5 minutes to re-run after push.")
-else:
-    print("Some agents had issues. Review logs in /tmp/fix_agent_pr*.log")
-EOF
+═══════════════════════════════════════════════════
 ```
 
 ---
@@ -563,14 +467,15 @@ Never manually resolve. Delete and regenerate after fixing `Cargo.toml`.
 
 ## Rules
 
+- **Sequential, not parallel** — fix one PR at a time. Wait for the user to merge before
+  moving to the next. This prevents cascade conflicts.
 - **Rebase over merge** where possible — keeps the history linear. Fall back to merge
   only if rebase produces unresolvable conflicts.
+- **Always fetch main before starting the next PR** — after a merge, main has changed.
+  The next PR must rebase onto the updated main.
 - **Never drop content** from either side of a documentation conflict (CLAUDE.md, README.md).
 - **Never delete tests** to make CI pass — fix the implementation.
 - **`cargo check` before `cargo clippy` before `cargo test`** — earlier failures mask later ones.
-- **One agent per PR** — agents do not coordinate. If two PRs both fix the same shared file
-  (e.g. `canon-core/src/types.rs`), each branch will have the fix independently after rebasing
-  onto main. That's correct.
 - **`--force-with-lease`** only — never `--force`. If the push is rejected because the remote
   was updated by someone else since the agent started, abort and report rather than overwriting.
 - **Use the LSP** — always verify types, definitions, and references via rust-analyzer before


### PR DESCRIPTION
## Summary

- Rewrites `/fix-prs` to process PRs **one at a time** instead of spawning parallel agents
- After fixing each PR, prompts the user to merge before moving to the next
- Fetches updated main after each merge so the next PR rebases onto current state

**Problem**: The parallel approach meant all PRs were fixed against the same stale main. Merging one would invalidate the rebase on the others, causing them to break again immediately.

**Solution**: Sequential flow: fix PR → push → prompt user "please merge now" → user merges → fetch main → fix next PR. Each PR always rebases onto the latest main including all previously merged fixes.

## Test plan

- [ ] Run `/fix-prs` with 2+ broken PRs
- [ ] Verify it fixes one, prompts to merge, waits for confirmation
- [ ] After confirming merge, verify it fetches main before fixing the next PR
- [ ] Verify "skip" option works to skip a PR without merging
- [ ] Verify final summary shows merged vs skipped counts