### PR TITLE
fix(fix-prs): resolve literal $FIX_SHA in PR comments

### DIFF
--- a/.claude/commands/fix-prs.md
+++ b/.claude/commands/fix-prs.md
@@ -358,7 +358,6 @@ git push --force-with-lease origin {branch}
 #### Step 7 — Post a comment on the PR
 
 ```bash
-FIX_SHA=$(git rev-parse HEAD)
 gh pr comment {number} --body "## fix-prs bot
 
 Branch has been rebased onto main and all CI failures resolved.
@@ -366,7 +365,7 @@ Branch has been rebased onto main and all CI failures resolved.
 **Changes made:**
 $(git log --oneline HEAD~1..HEAD)
 
-**Commit:** \`$FIX_SHA\`
+**Commit:** \`$(git rev-parse HEAD)\`
 
 _Run \`/review-prs\` to re-review code quality after this sync._"
 ```


### PR DESCRIPTION
## Summary
- The `/fix-prs` skill set `FIX_SHA` as a shell variable on one line then referenced `$FIX_SHA` in the `gh pr comment` call on the next. Claude executes each bash block as a separate tool call, so the variable was never in scope — leaving a literal `$FIX_SHA` in the PR comment.
- Replaced with an inline `$(git rev-parse HEAD)` subshell so it resolves within the single command.

## Test plan
- [ ] Run `/fix-prs` on a PR with CI failures and verify the comment shows an actual commit SHA instead of `$FIX_SHA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)