### PR TITLE
perf(canon-core): O(1) event combiner lookup via HashMap cache

### DIFF
--- a/canon-core/src/registration.rs
+++ b/canon-core/src/registration.rs
@@ -1,10 +1,20 @@
 use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use crate::EventEnvelope;
 
 /// Type-erased function that deserializes an event and applies it to aggregate state.
 pub type CombinerApplyFn =
     fn(&[u8], &mut dyn Any) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+/// Composite key for O(1) combiner lookup: (aggregate TypeId, event type name, event version).
+type CombinerKey = (TypeId, String, u32);
+
+/// Lazily-initialized lookup map from combiner key to apply function.
+/// Built once on first use from `inventory` registrations, then every
+/// subsequent lookup is O(1) instead of O(R).
+static COMBINER_MAP: OnceLock<HashMap<CombinerKey, CombinerApplyFn>> = OnceLock::new();
 
 // ── Event combiner registration ─────────────────────────────────────────────
 
@@ -90,25 +100,41 @@ inventory::collect!(ProjectionHandlerRegistration);
 
 /// Looks up the registered event combiner for this event envelope and applies it.
 /// Called from the `#[aggregate]` macro's generated `hydrate()`.
+///
+/// Uses a lazily-initialized `HashMap` for O(1) lookup per event instead of
+/// scanning all registered combiners linearly.
 #[doc(hidden)]
 pub fn __apply_event_combiner(
     aggregate_type_id: TypeId,
     envelope: &EventEnvelope,
     state: &mut dyn Any,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    for reg in inventory::iter::<EventCombinerRegistration> {
-        if reg.aggregate_type_id == aggregate_type_id
-            && reg.event_type_name == envelope.event_type
-            && reg.event_version == envelope.event_version
-        {
-            return (reg.apply_fn)(envelope.payload.as_ref(), state);
+    let map = COMBINER_MAP.get_or_init(|| {
+        let mut m = HashMap::new();
+        for reg in inventory::iter::<EventCombinerRegistration> {
+            let key: CombinerKey = (
+                reg.aggregate_type_id,
+                reg.event_type_name.to_owned(),
+                reg.event_version,
+            );
+            m.insert(key, reg.apply_fn);
         }
+        m
+    });
+
+    let key = (
+        aggregate_type_id,
+        envelope.event_type.clone(),
+        envelope.event_version,
+    );
+    match map.get(&key) {
+        Some(apply_fn) => apply_fn(envelope.payload.as_ref(), state),
+        None => Err(format!(
+            "no event combiner registered for '{}' version {}",
+            envelope.event_type, envelope.event_version
+        )
+        .into()),
     }
-    Err(format!(
-        "no event combiner registered for '{}' version {}",
-        envelope.event_type, envelope.event_version
-    )
-    .into())
 }
 
 /// Deserialize a JSON payload into a concrete type.


### PR DESCRIPTION
## Summary

- Replaces the O(E*R) linear scan in `__apply_event_combiner` with a `OnceLock<HashMap<CombinerKey, CombinerApplyFn>>` for O(1) lookups per event during aggregate hydration
- The map is built once on first use from `inventory` registrations, amortizing the cost across all subsequent hydrations
- Error behaviour for unregistered event types/versions is preserved unchanged

Closes #116.

## Test plan

- [x] All 131 existing `canon-core` tests pass (unit, macro integration, compile-fail)
- [x] Full workspace compiles cleanly (`cargo check --workspace`)
- [x] `cargo clippy -p canon-core -- -D warnings` passes with zero warnings
- [x] No `unwrap()`/`expect()` in library code
- [x] Existing error-path tests (`hydrate_returns_error_for_unregistered_event_type`, `hydrate_returns_error_for_unregistered_event_version`) continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)