### PR TITLE
docs: add LSP-first exploration rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -742,6 +742,11 @@ public_url = "/"
 
 ---
 
+## Codebase exploration
+
+Always use the LSP tool first when exploring the codebase — go-to-definition, find-references, hover for type info, and workspace symbol search. Fall back to Grep/Glob only when LSP doesn't cover what you need.
+
+---
 ## What to do when stuck
 
 1. Re-read the relevant section of this file.


### PR DESCRIPTION
## Summary
- Adds a "Codebase exploration" section to CLAUDE.md instructing Claude Code to always use the LSP tool first (go-to-definition, find-references, hover, symbol search) before falling back to Grep/Glob

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm Claude Code respects the new instruction in future conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)