### PR TITLE
docs: loosen mockup from pixel-perfect spec to design guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,10 +458,22 @@ WS: `/events` — broadcast all DemoEvent as JSON
 ### Frontend (Leptos WASM)
 
 The frontend is a Leptos 0.7 CSR WASM application built with Trunk. It lives at
-`canon-demo/frontend/`. The **authoritative visual reference** is
-`canon-demo/frontend/reference/mockup.html` — open it in a browser. Every pixel,
-animation, colour, interaction, and layout must match that file. When in doubt, the
-mockup wins.
+`canon-demo/frontend/`. The **visual reference** is
+`canon-demo/frontend/reference/mockup.html` — open it in a browser.
+
+The mockup is a static HTML prototype with faked data and `setTimeout` chains. Use it
+as a **reference for design tokens and interaction flows**, not as a pixel-perfect
+specification:
+
+- **Extract from the mockup**: CSS variables, colour palette, fonts, spacing, layout
+  proportions, interaction patterns (what happens when you click X), and scenario flow
+  sequences.
+- **Do not mimic**: its DOM structure, `setTimeout`-based animation timing, or inline JS
+  patterns. The Leptos app should use idiomatic reactive signals, composable components,
+  and CSS-driven animations.
+- **Free to improve**: responsive behaviour, accessibility, animation polish, and
+  handling of real data edge cases (empty states, reconnection, error feedback) may
+  diverge from the mockup where the real app benefits.
 
 ---
 
@@ -726,7 +738,7 @@ public_url = "/"
 #### Acceptance criteria (all must pass before merge)
 
 - [ ] `trunk build --release` produces a working WASM bundle, zero errors
-- [ ] Visual output matches `reference/mockup.html` at 1440px viewport
+- [ ] Visual language (colours, fonts, layout proportions) consistent with `reference/mockup.html`
 - [ ] Ships fly autonomously from page load, loop indefinitely
 - [ ] Clicking a ship shows popup with correct version/snapshot data
 - [ ] Selecting a destination departs the ship and fires the full event chain


### PR DESCRIPTION
## Summary
- Reframes `mockup.html` from "authoritative visual reference — every pixel must match" to a **design token and interaction flow reference**
- Clarifies what to extract (CSS variables, colours, fonts, layout proportions, interaction patterns) and what not to mimic (DOM structure, setTimeout timing, inline JS)
- Explicitly grants freedom to improve responsive behaviour, accessibility, animation polish, and real data edge cases
- Updates acceptance criteria from "visual output matches mockup at 1440px" to "visual language consistent with mockup"

## Why
The mockup is a 1140-line static HTML file with faked data and `setTimeout` chains. Pixel-matching it pushes toward monolithic views and JS-hack animations instead of idiomatic Leptos signals and composable components. It also freezes the UI — any improvement to the real app creates a false "disagreement" with the mockup.

## Test plan
- [ ] Read the updated CLAUDE.md frontend section and confirm guidance is clear
- [ ] Verify no other files reference "mockup wins" or "every pixel"

🤖 Generated with [Claude Code](https://claude.com/claude-code)