### PR TITLE
fix(frontend): align idempotency scenario with mockup reference

### DIFF
--- a/canon-demo/frontend/src/scenarios/idempotency.rs
+++ b/canon-demo/frontend/src/scenarios/idempotency.rs
@@ -71,7 +71,7 @@ pub fn IdempotencyScenario(close_signal: RwSignal<bool>) -> impl IntoView {
                 ));
 
                 let cb = gloo_timers::callback::Timeout::new(800, move || {
-                    button_text.set("Simulate Network Retry \u{2192}".into());
+                    button_text.set("Simulate Network Retry (duplicate) \u{2192}".into());
                 });
                 cb.forget();
             }
@@ -114,7 +114,8 @@ pub fn IdempotencyScenario(close_signal: RwSignal<bool>) -> impl IntoView {
                 });
                 cb1.forget();
 
-                let cb2 = gloo_timers::callback::Timeout::new(1400, move || {
+                let cb2 = gloo_timers::callback::Timeout::new(1600, move || {
+                    current_step.set(3);
                     let corr3 = fresh_corr();
                     push_sc_log(log, "fleet", "sf", "ShipDeparted", "VSS KRONOS", &corr3);
                     let corr3b = fresh_corr();
@@ -125,7 +126,7 @@ pub fn IdempotencyScenario(close_signal: RwSignal<bool>) -> impl IntoView {
                 });
                 cb2.forget();
 
-                let cb4 = gloo_timers::callback::Timeout::new(2200, move || {
+                let cb4 = gloo_timers::callback::Timeout::new(2400, move || {
                     phase.set(Phase::Complete);
                     current_step.set(4);
                     success_title.set("Idempotency demonstrated".into());


### PR DESCRIPTION
## Summary
Mission 05 (The Duplicate Signal) had three discrepancies with the mockup reference: the "Confirm" step (step 3) was skipped in the progress bar, the retry button was missing the "(duplicate)" label, and timer offsets were compressed vs the reference.

## Changes
- **Step progression**: Added `current_step.set(3)` when ShipDeparted fires at 1600ms, so the "Confirm" step lights up before the final "Complete" step
- **Button text**: Changed "Simulate Network Retry →" to "Simulate Network Retry (duplicate) →" to match mockup
- **Timer alignment**: Adjusted offsets from 1400/2200ms to 1600/2400ms to match the mockup's nested setTimeout chain (600 + 1000 = 1600, 600 + 1000 + 800 = 2400)

## Testing
- `cargo check -p frontend` passes
- `cargo clippy -p frontend -- -D warnings` passes
- `cargo fmt --check -p frontend` passes
- All acceptance criteria from #134 are met by the existing + corrected implementation

Closes #134