### PR TITLE
feat(gateway): add missing REST endpoints and fix dead letter requeue

### DIFF
--- a/canon-demo/gateway/src/routes/admin.rs
+++ b/canon-demo/gateway/src/routes/admin.rs
@@ -174,18 +174,28 @@ async fn requeue_dead_letter(
 
     let mut tx = state.yugabyte_pool.begin().await?;
 
-    // Re-insert into inbox_messages with the same message data
+    // Re-insert into inbox_messages with a fresh message_id so the requeued
+    // message is treated as a new attempt (the original message_id may still
+    // exist in inbox_messages from the failed processing run).
+    let fresh_message_id = Uuid::new_v4();
     sqlx::query(
         "INSERT INTO inbox_messages (handler_id, message_id, aggregate_id, message_type, payload) \
          VALUES ($1, $2, $3, 'requeued', $4) \
          ON CONFLICT DO NOTHING",
     )
     .bind(&handler_id)
-    .bind(row.message_id)
+    .bind(fresh_message_id)
     .bind(row.aggregate_id)
     .bind(&row.payload)
     .execute(&mut *tx)
     .await?;
+
+    // Clear retry attempts for the original message so the requeued copy
+    // does not inherit the previous failure count.
+    sqlx::query("DELETE FROM retry_attempts WHERE message_id = $1")
+        .bind(row.message_id)
+        .execute(&mut *tx)
+        .await?;
 
     // Remove from dead_letters
     sqlx::query("DELETE FROM dead_letters WHERE id = $1")

--- a/canon-demo/gateway/src/routes/cargo.rs
+++ b/canon-demo/gateway/src/routes/cargo.rs
@@ -12,13 +12,15 @@ use crate::correlation::{extract_correlation_id, CORRELATION_HEADER};
 use crate::error::GatewayError;
 use crate::state::AppState;
 use crate::types::{
-    CommandAcceptedResponse, CreateManifestRequest, EventHistoryEntry, LoadCargoRequest,
+    BeginUnloadingRequest, CommandAcceptedResponse, CreateManifestRequest, EventHistoryEntry,
+    LoadCargoRequest,
 };
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/cargo/manifests", post(create_manifest))
         .route("/cargo/manifests/{id}/load", post(load_cargo))
+        .route("/cargo/manifests/{id}/unload", post(begin_unloading))
         .route("/cargo/manifests/{id}", get(manifest_history))
 }
 
@@ -74,6 +76,45 @@ async fn load_cargo(
     };
 
     let envelope = build_envelope("LoadCargo", Some(id), corr_id, &payload)?;
+    let response = CommandAcceptedResponse {
+        command_id: envelope.command_id,
+        aggregate_id: id,
+        correlation_id: corr_id,
+    };
+
+    submit_command(&state.yugabyte_pool, "Manifest", &envelope).await?;
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        CORRELATION_HEADER,
+        corr_id.to_string().parse().map_err(|_| {
+            GatewayError::Internal("failed to format correlation header".to_owned())
+        })?,
+    );
+
+    Ok((resp_headers, Json(response)))
+}
+
+/// POST /cargo/manifests/:id/unload — BeginUnloading command
+async fn begin_unloading(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<BeginUnloadingRequest>,
+) -> Result<(HeaderMap, Json<CommandAcceptedResponse>), GatewayError> {
+    let corr_id = extract_correlation_id(&headers);
+
+    #[derive(serde::Serialize)]
+    struct Payload {
+        manifest_id: Uuid,
+        station_id: Uuid,
+    }
+    let payload = Payload {
+        manifest_id: id,
+        station_id: body.station_id,
+    };
+
+    let envelope = build_envelope("BeginUnloading", Some(id), corr_id, &payload)?;
     let response = CommandAcceptedResponse {
         command_id: envelope.command_id,
         aggregate_id: id,

--- a/canon-demo/gateway/src/routes/navigation.rs
+++ b/canon-demo/gateway/src/routes/navigation.rs
@@ -1,16 +1,22 @@
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::HeaderMap;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use uuid::Uuid;
+
+use canon_core::AggregateId;
+use canon_event_store::EventStore;
 
 use crate::command::{build_envelope, submit_command};
 use crate::correlation::{extract_correlation_id, CORRELATION_HEADER};
 use crate::error::GatewayError;
 use crate::state::AppState;
-use crate::types::{CommandAcceptedResponse, PlanRouteRequest};
+use crate::types::{CommandAcceptedResponse, EventHistoryEntry, PlanRouteRequest};
 
 pub fn router() -> Router<AppState> {
-    Router::new().route("/navigation/routes", post(plan_route))
+    Router::new()
+        .route("/navigation/routes", post(plan_route))
+        .route("/navigation/routes/{id}", get(route_history))
 }
 
 /// POST /navigation/routes — PlanRoute command
@@ -39,4 +45,36 @@ async fn plan_route(
     );
 
     Ok((resp_headers, Json(response)))
+}
+
+/// GET /navigation/routes/:id — load route event history from Cassandra
+async fn route_history(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Vec<EventHistoryEntry>>, GatewayError> {
+    let agg_id = AggregateId::from_uuid(id);
+    let events = state.event_store.load(&agg_id).await?;
+
+    if events.is_empty() {
+        return Err(GatewayError::NotFound(format!("route {id} not found")));
+    }
+
+    let entries = events
+        .into_iter()
+        .map(|e| {
+            let payload: serde_json::Value =
+                serde_json::from_slice(&e.payload).unwrap_or(serde_json::Value::Null);
+            EventHistoryEntry {
+                event_id: e.event_id,
+                version: e.version.as_u64(),
+                event_type: e.event_type,
+                event_version: e.event_version,
+                correlation_id: e.correlation_id,
+                timestamp: e.timestamp.to_rfc3339(),
+                payload,
+            }
+        })
+        .collect();
+
+    Ok(Json(entries))
 }

--- a/canon-demo/gateway/src/routes/station.rs
+++ b/canon-demo/gateway/src/routes/station.rs
@@ -9,13 +9,16 @@ use crate::correlation::{extract_correlation_id, CORRELATION_HEADER};
 use crate::error::GatewayError;
 use crate::state::AppState;
 use crate::types::{
-    CommandAcceptedResponse, RegisterStationRequest, StationInventoryResponse, StationStateResponse,
+    CommandAcceptedResponse, RecordCargoReceivedRequest, RecordDockingRequest,
+    RegisterStationRequest, StationInventoryResponse, StationStateResponse,
 };
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/stations", get(list_stations))
         .route("/stations/{id}/register", post(register_station))
+        .route("/stations/{id}/dock", post(record_docking))
+        .route("/stations/{id}/cargo", post(record_cargo_received))
         .route("/stations/{id}/inventory", get(station_inventory))
 }
 
@@ -29,6 +32,86 @@ async fn register_station(
     let corr_id = extract_correlation_id(&headers);
     let envelope = build_envelope("RegisterStation", Some(id), corr_id, &body)?;
 
+    let response = CommandAcceptedResponse {
+        command_id: envelope.command_id,
+        aggregate_id: id,
+        correlation_id: corr_id,
+    };
+
+    submit_command(&state.yugabyte_pool, "Station", &envelope).await?;
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        CORRELATION_HEADER,
+        corr_id.to_string().parse().map_err(|_| {
+            GatewayError::Internal("failed to format correlation header".to_owned())
+        })?,
+    );
+
+    Ok((resp_headers, Json(response)))
+}
+
+/// POST /stations/:id/dock — RecordDocking command
+async fn record_docking(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<RecordDockingRequest>,
+) -> Result<(HeaderMap, Json<CommandAcceptedResponse>), GatewayError> {
+    let corr_id = extract_correlation_id(&headers);
+
+    #[derive(serde::Serialize)]
+    struct Payload {
+        station_id: Uuid,
+        ship_id: Uuid,
+    }
+    let payload = Payload {
+        station_id: id,
+        ship_id: body.ship_id,
+    };
+
+    let envelope = build_envelope("RecordDocking", Some(id), corr_id, &payload)?;
+    let response = CommandAcceptedResponse {
+        command_id: envelope.command_id,
+        aggregate_id: id,
+        correlation_id: corr_id,
+    };
+
+    submit_command(&state.yugabyte_pool, "Station", &envelope).await?;
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        CORRELATION_HEADER,
+        corr_id.to_string().parse().map_err(|_| {
+            GatewayError::Internal("failed to format correlation header".to_owned())
+        })?,
+    );
+
+    Ok((resp_headers, Json(response)))
+}
+
+/// POST /stations/:id/cargo — RecordCargoReceived command
+async fn record_cargo_received(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(body): Json<RecordCargoReceivedRequest>,
+) -> Result<(HeaderMap, Json<CommandAcceptedResponse>), GatewayError> {
+    let corr_id = extract_correlation_id(&headers);
+
+    #[derive(serde::Serialize)]
+    struct Payload {
+        station_id: Uuid,
+        manifest_id: Uuid,
+        weight_kg: f32,
+    }
+    let payload = Payload {
+        station_id: id,
+        manifest_id: body.manifest_id,
+        weight_kg: body.weight_kg,
+    };
+
+    let envelope = build_envelope("RecordCargoReceived", Some(id), corr_id, &payload)?;
     let response = CommandAcceptedResponse {
         command_id: envelope.command_id,
         aggregate_id: id,

--- a/canon-demo/gateway/src/routes/supply.rs
+++ b/canon-demo/gateway/src/routes/supply.rs
@@ -1,7 +1,8 @@
 use axum::extract::State;
 use axum::http::HeaderMap;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use uuid::Uuid;
 
 use crate::command::{build_envelope, submit_command};
 use crate::correlation::{extract_correlation_id, CORRELATION_HEADER};
@@ -10,7 +11,9 @@ use crate::state::AppState;
 use crate::types::{CommandAcceptedResponse, RequestResupplyRequest};
 
 pub fn router() -> Router<AppState> {
-    Router::new().route("/supply/resupply", post(request_resupply))
+    Router::new()
+        .route("/supply/resupply", post(request_resupply))
+        .route("/supply/inventory", get(list_inventory))
 }
 
 /// POST /supply/resupply — RequestResupply command
@@ -39,4 +42,25 @@ async fn request_resupply(
     );
 
     Ok((resp_headers, Json(response)))
+}
+
+/// Inventory row from the supply_inventory projection table.
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+struct InventoryRow {
+    inventory_id: Uuid,
+    station_id: Uuid,
+    fuel_kg: f32,
+}
+
+/// GET /supply/inventory — list all inventory records from the supply_inventory projection
+async fn list_inventory(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<InventoryRow>>, GatewayError> {
+    let rows: Vec<InventoryRow> = sqlx::query_as(
+        "SELECT inventory_id, station_id, fuel_kg FROM supply_inventory ORDER BY station_id",
+    )
+    .fetch_all(&state.yugabyte_pool)
+    .await?;
+
+    Ok(Json(rows))
 }

--- a/canon-demo/gateway/src/types.rs
+++ b/canon-demo/gateway/src/types.rs
@@ -158,6 +158,22 @@ pub struct RegisterStationRequest {
     pub capacity_kg: f32,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct BeginUnloadingRequest {
+    pub station_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordDockingRequest {
+    pub ship_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordCargoReceivedRequest {
+    pub manifest_id: Uuid,
+    pub weight_kg: f32,
+}
+
 // ── Event history response ──────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

Completes the gateway REST API surface by adding 5 missing endpoints and fixes a bug in the dead letter requeue flow where reusing the original `message_id` could silently fail due to `ON CONFLICT DO NOTHING`.

## Changes

- **cargo**: add `POST /cargo/manifests/:id/unload` (BeginUnloading command)
- **navigation**: add `GET /navigation/routes/:id` (event history from Cassandra)
- **supply**: add `GET /supply/inventory` (projection read from `supply_inventory` table)
- **station**: add `POST /stations/:id/dock` (RecordDocking) and `POST /stations/:id/cargo` (RecordCargoReceived)
- **admin**: fix dead letter requeue to generate a fresh `message_id` for the re-inserted inbox message, avoiding silent idempotency conflicts with the original row
- **admin**: clear `retry_attempts` for the original message during requeue so the new attempt starts with a clean retry count
- **types**: add `BeginUnloadingRequest`, `RecordDockingRequest`, `RecordCargoReceivedRequest`

## Testing

- `cargo check -p gateway` passes with zero warnings
- `cargo clippy -p gateway -- -D warnings` passes
- `cargo fmt -p gateway --check` passes

## Assumptions

- `GET /supply/inventory` reads from a `supply_inventory` projection table with columns `(inventory_id, station_id, fuel_kg)` — this table will be created by the supply service's projection consumer
- `GET /navigation/routes/:id` returns raw event history (read-through from Cassandra), consistent with `GET /ships/:id/history` and `GET /cargo/manifests/:id`

Closes #129