### PR TITLE
chore(review-prs): fix all severity levels, not just blockers and should-fix

### DIFF
--- a/.claude/commands/review-prs.md
+++ b/.claude/commands/review-prs.md
@@ -249,9 +249,9 @@ _Previously raised issues that are still open are not re-commented — see earli
 
 ---
 
-## PHASE F — Fix all issues and commit
+## PHASE F — Fix ALL issues and commit
 
-Fix every 🔴 blocker and 🟡 should-fix issue you found. Apply fixes directly to the checked-out branch.
+Fix every issue you found — 🔴 blockers, 🟡 should-fix, AND 🟢 nice-to-have. Every single issue raised in the review must be resolved. Apply fixes directly to the checked-out branch.
 
 Work through fixes in dependency order:
 1. Fixes to `canon-core` first (type additions, trait changes)
@@ -288,7 +288,7 @@ review-prs-sha: $FIX_SHA
 
 ## Fix commit
 
-Applied fixes for all 🔴 and 🟡 issues from the review above.
+Applied fixes for all issues (🔴, 🟡, and 🟢) from the review above.
 Commit: \`$FIX_SHA\`
 
 Changes:


### PR DESCRIPTION
## Summary

The `/review-prs` skill previously only fixed 🔴 blocker and 🟡 should-fix issues, leaving 🟢 nice-to-have issues for the author to address manually. Now every issue raised in the review — regardless of severity — is fixed automatically.

## Changes

- Phase F header and instructions updated to explicitly include all three severity levels
- Follow-up commit comment updated to reference all severities

🤖 Generated with [Claude Code](https://claude.ai/claude-code)