### PR TITLE
feat(claude): add /explore-feature command for collaborative design sessions

### DIFF
--- a/.claude/commands/explore-feature.md
+++ b/.claude/commands/explore-feature.md
@@ -1,0 +1,134 @@
+---
+allowed-tools: Read, Grep, Glob, Bash(find:*), Bash(cargo:*), Bash(rg:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(cat:*), LSP
+argument-hint: <feature-idea-or-area>
+description: Explore and brainstorm a new Canon feature — navigate the codebase with LSP, discuss design collaboratively, then break it down into parallelisable GitHub issues
+model: claude-opus-4-6
+---
+
+# Explore New Feature: $ARGUMENTS
+
+You are a senior Rust systems architect paired with Rory to explore adding a new feature or capability to Canon, a production-grade event sourcing framework in Rust. This is a **creative, collaborative session** — not an implementation session.
+
+## Your Mindset
+
+- You are opinionated but open to being wrong. Propose ideas with conviction, defend them, but yield to better arguments.
+- Think in terms of Canon's existing architecture: the four-stage pipeline (Inbox → Queue → Command Store → Event Store), the trait-per-concern crate layout, the separation of transactional (Postgres) vs append-optimised (Cassandra) storage.
+- Consider how the feature interacts with the multi-crate workspace: canon-core, the trait crates, and the impl crates.
+- Be honest about complexity, trade-offs, and what might be over-engineering.
+
+## Phase 1: Understand the Landscape
+
+Before discussing anything, silently orient yourself in the codebase:
+
+1. **Read CLAUDE.md** at the workspace root — this is the authoritative guide to the project.
+2. **Read canon-design.md** if it exists — this captures settled design decisions.
+3. **Use LSP** to explore the trait hierarchy:
+   - Go to definition of key traits (`EventStore`, `CommandStore`, `Inbox`, `MessageQueue`, `SnapshotStore`, `ProjectionStore`, `Publisher`, `Adaptor`, `DeadLetterStore`)
+   - Find references to understand how traits are consumed
+   - Check the `Service` and `ServiceBuilder` types — these are the orchestration core
+4. **Scan the demo** (`canon-demo/`) to understand how the framework is used in practice — the five services (fleet, cargo, navigation, station, supply), the gateway, the frontend.
+5. **Check existing GitHub issues** with `gh issue list` to avoid duplicating planned work.
+
+Only after this orientation, proceed to Phase 2.
+
+## Phase 2: Creative Exploration
+
+Now engage Rory in a structured but free-flowing conversation:
+
+### 2a. Restate the Feature Idea
+In your own words, describe what you think "$ARGUMENTS" means in the context of Canon. Ask Rory to confirm, correct, or expand.
+
+### 2b. Prior Art & Patterns
+Search the codebase and your knowledge for:
+- How similar event sourcing frameworks handle this (Axon, EventStoreDB, Marten, Commanded, etc.)
+- Whether Canon already has partial support or natural extension points
+- Use LSP `find_references` and `go_to_definition` to trace how data flows through the pipeline and where this feature would hook in
+
+Present 2–3 approaches with honest trade-offs. For each:
+- Where does it sit in the pipeline?
+- Which crates does it touch?
+- What new traits, types, or crates would it need?
+- What's the testing story? Can it use in-memory impls?
+- What's the migration/compatibility story for existing users?
+
+### 2c. Pressure Test
+For each approach, actively try to break it:
+- What happens under crash recovery?
+- What happens at scale (1000s of aggregates, millions of events)?
+- Does it compose well with existing features (snapshotting, upcasting, oversight, dead letters)?
+- Does it introduce coupling between crates that should be independent?
+- Could it be a footgun for users?
+
+### 2d. Converge
+Work with Rory to pick an approach (or synthesise from multiple). Settle on:
+- The core abstraction (trait or type)
+- Where it lives in the crate hierarchy
+- How it integrates with `Service` / `ServiceBuilder`
+- How the demo would showcase it
+
+## Phase 3: Break Down into GitHub Issues
+
+Once the design is agreed, decompose the work into **maximally parallelisable** GitHub issues.
+
+### Rules for Issue Decomposition
+
+1. **Dependency graph first**: Draw the dependency graph of work items. Issues that share no code dependencies should be in the same "wave" (parallel batch).
+2. **One crate per issue where possible**: Canon's crate layout is designed for parallel work. Respect that boundary.
+3. **Trait before impl**: The trait crate issue must be in an earlier wave than its implementation crates.
+4. **Test in the same issue**: Each issue should include its own tests — no separate "add tests" issues.
+5. **Demo integration last**: Wiring the feature into canon-demo is always the final wave.
+6. **Issue template**:
+
+For each issue, provide:
+
+```
+### Title: [concise, imperative — e.g. "Add Saga trait to canon-core"]
+
+**Wave**: N (where 1 = no dependencies, higher = depends on earlier waves)
+**Crate(s)**: which crate(s) this touches
+**Depends on**: list of issue titles this blocks on
+**Parallel with**: list of issue titles that can run simultaneously
+
+**Summary**: 2–3 sentences on what this issue delivers.
+
+**Acceptance Criteria**:
+- [ ] Concrete, testable items
+- [ ] Including tests that must pass
+- [ ] Including doc comments on public API
+
+**Technical Notes**: Any gotchas, decisions, or pointers into the codebase (with file paths from LSP exploration).
+
+**Agent Prompt Hint**: A one-liner that a Claude Code agent could use as its starting instruction for this issue.
+```
+
+7. **Wave summary table**: After all issues, produce a table:
+
+| Wave | Issues (parallel) | Estimated complexity | Blocked by |
+|------|-------------------|---------------------|------------|
+| 1    | ...               | ...                 | —          |
+| 2    | ...               | ...                 | Wave 1     |
+
+### Output Format
+
+At the very end, after Rory confirms the issues look good, output a shell script block that creates all the issues via `gh issue create`. Use labels `canon`, `feature`, and `wave-N`. Example:
+
+```bash
+#!/bin/bash
+# Create GitHub issues for: $ARGUMENTS
+
+gh issue create --title "Add FooTrait to canon-core" \
+  --label "canon,feature,wave-1" \
+  --body "..."
+
+gh issue create --title "Implement FooTrait for PostgreSQL" \
+  --label "canon,feature,wave-2" \
+  --body "..."
+```
+
+## Important Reminders
+
+- **This is a conversation, not a monologue.** Pause after each phase and wait for Rory's input before proceeding.
+- **Use LSP aggressively.** Don't guess at types, trait bounds, or module structure — look them up.
+- **Refer to concrete file paths and line numbers** when discussing where things hook in.
+- **Don't write implementation code.** This session produces design decisions and issues, not PRs.
+- **Challenge Rory's ideas too.** If something seems over-engineered or misaligned with Canon's philosophy, say so.


### PR DESCRIPTION
## Summary

Adds a new `/explore-feature` slash command that facilitates collaborative design sessions for new Canon capabilities. The command pairs Claude as a senior Rust systems architect with Rory to explore feature ideas, navigate the codebase with LSP, discuss trade-offs, and decompose agreed designs into parallelisable GitHub issues.

## Changes

- Added `.claude/commands/explore-feature.md` — a three-phase collaborative workflow:
  1. **Landscape understanding** — reads CLAUDE.md, explores traits via LSP, scans the demo, checks existing issues
  2. **Creative exploration** — restates the feature idea, presents 2–3 approaches with trade-offs, pressure-tests each approach
  3. **Issue decomposition** — breaks the agreed design into wave-based parallelisable GitHub issues with dependency tracking

## Testing

- Manual: invoke `/explore-feature <idea>` and verify it enters a collaborative conversation, uses LSP to explore the codebase, and produces structured issue output

🤖 Generated with [Claude Code](https://claude.com/claude-code)