### PR TITLE
fix(infra): add dual Kafka listeners for host-mode development

### DIFF
--- a/canon-demo/docker-compose.yml
+++ b/canon-demo/docker-compose.yml
@@ -44,6 +44,11 @@ services:
       timeout: 5s
       retries: 10
 
+  # Dual-listener Kafka setup:
+  #   INTERNAL (port 9092) — used by Docker-internal services via kafka:9092
+  #   EXTERNAL (port 9093) — used by host-mode services via localhost:9093
+  # This avoids the problem where Kafka advertises kafka:9092 in metadata,
+  # which is unresolvable from the host.
   kafka:
     image: confluentinc/cp-kafka:7.7.1
     depends_on:
@@ -51,10 +56,14 @@ services:
         condition: service_healthy
     ports:
       - "9092:9092"
+      - "9093:9093"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
     healthcheck:


### PR DESCRIPTION
## Summary
Adds dual Kafka listeners for Docker-internal and host-mode connections — closes #173.

## What's included
- INTERNAL listener on port 9092 (advertised as `kafka:9092`) for Docker-internal services
- EXTERNAL listener on port 9093 (advertised as `localhost:9093`) for host-mode development
- Port 9093 exposed in docker-compose

## Root cause
Kafka's advertised listeners tell clients where to reconnect after initial metadata fetch. With only `PLAINTEXT://kafka:9092`, host-mode services connect to `localhost:9092` initially but are then told to reconnect to `kafka:9092`, which doesn't resolve on the host.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)