### PR TITLE
fix(init-schema): use CQL-compatible comments in cassandra.cql

### DIFF
--- a/canon-demo/init-schema/cassandra.cql
+++ b/canon-demo/init-schema/cassandra.cql
@@ -1,5 +1,5 @@
--- Canon Cassandra schema initialisation
--- Runs as an init container before services start.
+// Canon Cassandra schema initialisation
+// Runs as an init container before services start.
 
 CREATE KEYSPACE IF NOT EXISTS canon
     WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};


### PR DESCRIPTION
## Summary
- Replaced `--` (SQL-style) comments with `//` (CQL-compatible) comments in `cassandra.cql` — closes #174

## Root cause
`cqlsh` does not reliably handle `--` comments. The `CREATE KEYSPACE` statement was silently skipped, leaving the `canon` keyspace uncreated. All services then failed on startup with "Keyspace 'canon' does not exist".

## Test plan
- [ ] Run `cqlsh -f cassandra.cql` and verify the `canon` keyspace and `canon.events` table are created
- [ ] Run the init-schema container in docker-compose and confirm services start successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)