### PR TITLE
fix(docker): use nightly Rust in all Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.claude/worktrees/
+.git/

--- a/canon-demo/cargo-service/Dockerfile
+++ b/canon-demo/cargo-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p cargo-service

--- a/canon-demo/fleet-service/Dockerfile
+++ b/canon-demo/fleet-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p fleet-service

--- a/canon-demo/frontend/Dockerfile
+++ b/canon-demo/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 RUN rustup target add wasm32-unknown-unknown
 RUN cargo install trunk wasm-bindgen-cli
 WORKDIR /app

--- a/canon-demo/gateway/Dockerfile
+++ b/canon-demo/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p gateway

--- a/canon-demo/navigation-service/Dockerfile
+++ b/canon-demo/navigation-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p navigation-service

--- a/canon-demo/station-service/Dockerfile
+++ b/canon-demo/station-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p station-service

--- a/canon-demo/supply-service/Dockerfile
+++ b/canon-demo/supply-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 AS builder
+FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p supply-service


### PR DESCRIPTION
## Summary
Fixes all 7 Dockerfiles to use `rustlang/rust:nightly` — closes #172.

## What's included
- Updated all 7 Dockerfiles (5 services + gateway + frontend) to use nightly Rust
- Added `.dockerignore` to exclude `target/`, `.claude/worktrees/`, `.git/` from Docker context (prevents 2.5GB context transfer)

## Root cause
The codebase uses `TypeId::of` in const contexts via `inventory` static registrations in canon-core macros. This feature requires nightly Rust (~1.94+). The official `rust:` Docker Hub images only go up to stable, so we use `rustlang/rust:nightly`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)