### PR TITLE
fix(frontend): wire up scenarios tab routing

### DIFF
--- a/canon-demo/frontend/Cargo.toml
+++ b/canon-demo/frontend/Cargo.toml
@@ -18,8 +18,10 @@ web-sys = { version = "0.3", features = [
     "HtmlElement",
     "Element",
     "DomTokenList",
+    "EventTarget",
     "Location",
     "BinaryType",
+    "History",
 ] }
 gloo-net = { version = "0.6", features = ["http", "websocket"] }
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/canon-demo/frontend/src/app.rs
+++ b/canon-demo/frontend/src/app.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
 
 use crate::hydrate::hydrate_from_gateway;
 use crate::pages::live_fleet::LiveFleetPage;
@@ -10,9 +11,52 @@ use crate::scenarios::snapshot::SnapshotScenario;
 use crate::state::{create_app_state, ActiveTab, AppState, ConnectionStatus};
 use crate::ws::connect_ws;
 
+/// Read the browser's current pathname and return the matching tab.
+fn initial_tab_from_url() -> ActiveTab {
+    web_sys::window()
+        .and_then(|w| w.location().pathname().ok())
+        .map(|p| {
+            if p == "/scenarios" || p.starts_with("/scenarios/") {
+                ActiveTab::Scenarios
+            } else {
+                ActiveTab::LiveFleet
+            }
+        })
+        .unwrap_or(ActiveTab::LiveFleet)
+}
+
+/// Push a history entry so the URL bar reflects the active tab.
+fn push_tab_url(tab: ActiveTab) {
+    if let Some(window) = web_sys::window() {
+        if let Ok(history) = window.history() {
+            let path = match tab {
+                ActiveTab::LiveFleet => "/",
+                ActiveTab::Scenarios => "/scenarios",
+            };
+            let _ = history.push_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(path));
+        }
+    }
+}
+
 #[component]
 pub fn App() -> impl IntoView {
     let state = create_app_state();
+
+    // Set initial tab based on URL path (e.g. /scenarios).
+    state.active_tab.set(initial_tab_from_url());
+
+    // Handle browser back/forward navigation via popstate.
+    {
+        let active_tab = state.active_tab;
+        let cb = wasm_bindgen::closure::Closure::<dyn Fn()>::new(move || {
+            active_tab.set(initial_tab_from_url());
+        });
+        if let Some(window) = web_sys::window() {
+            let _ =
+                window.add_event_listener_with_callback("popstate", cb.as_ref().unchecked_ref());
+        }
+        cb.forget(); // leak intentionally — lives for app lifetime
+    }
 
     // Connect WebSocket and hydrate from gateway on mount
     Effect::new(move |_| {
@@ -112,7 +156,10 @@ fn TopNav(state: AppState) -> impl IntoView {
                         "nav-tab"
                     }
                 }
-                on:click=move |_| active.set(ActiveTab::LiveFleet)
+                on:click=move |_| {
+                    active.set(ActiveTab::LiveFleet);
+                    push_tab_url(ActiveTab::LiveFleet);
+                }
             >
                 "Live Fleet"
             </div>
@@ -124,7 +171,10 @@ fn TopNav(state: AppState) -> impl IntoView {
                         "nav-tab"
                     }
                 }
-                on:click=move |_| active.set(ActiveTab::Scenarios)
+                on:click=move |_| {
+                    active.set(ActiveTab::Scenarios);
+                    push_tab_url(ActiveTab::Scenarios);
+                }
             >
                 "Scenarios"
             </div>
@@ -211,55 +261,57 @@ fn ScenariosPage() -> impl IntoView {
     });
 
     view! {
-        <div class="sc-hero">
-            <div class="sc-hero-title">"Canon Feature Scenarios"</div>
-            <div class="sc-hero-sub">
-                "Each mission showcases a specific Canon capability. Follow the narrative, trigger the events, and watch the framework respond in real time."
+        <div class="scenarios-page">
+            <div class="sc-hero">
+                <div class="sc-hero-title">"Canon Feature Scenarios"</div>
+                <div class="sc-hero-sub">
+                    "Each mission showcases a specific Canon capability. Follow the narrative, trigger the events, and watch the framework respond in real time."
+                </div>
             </div>
-        </div>
-        <div class="sc-grid">
-            {missions
-                .into_iter()
-                .map(|(num, name, ship, desc, tags, scenario_id)| {
-                    let on_launch = move |_| {
-                        active_scenario.set(Some(scenario_id));
-                    };
-                    view! {
-                        <div class="sc-card" on:click=on_launch>
-                            <div class="sc-num">{num}</div>
-                            <div class="sc-name">{name}</div>
-                            <div class="sc-ship">{ship}</div>
-                            <div class="sc-desc">{desc}</div>
-                            <div class="sc-tags">
-                                {tags
-                                    .into_iter()
-                                    .map(|tag| {
-                                        view! { <span class="sc-tag">{tag}</span> }
-                                    })
-                                    .collect::<Vec<_>>()}
+            <div class="sc-grid">
+                {missions
+                    .into_iter()
+                    .map(|(num, name, ship, desc, tags, scenario_id)| {
+                        let on_launch = move |_| {
+                            active_scenario.set(Some(scenario_id));
+                        };
+                        view! {
+                            <div class="sc-card" on:click=on_launch>
+                                <div class="sc-num">{num}</div>
+                                <div class="sc-name">{name}</div>
+                                <div class="sc-ship">{ship}</div>
+                                <div class="sc-desc">{desc}</div>
+                                <div class="sc-tags">
+                                    {tags
+                                        .into_iter()
+                                        .map(|tag| {
+                                            view! { <span class="sc-tag">{tag}</span> }
+                                        })
+                                        .collect::<Vec<_>>()}
+                                </div>
+                                <div class="sc-launch">"Launch Mission \u{2192}"</div>
                             </div>
-                            <div class="sc-launch">"Launch Mission \u{2192}"</div>
-                        </div>
-                    }
-                })
-                .collect::<Vec<_>>()}
-        </div>
+                        }
+                    })
+                    .collect::<Vec<_>>()}
+            </div>
 
-        // Scenario runners
-        <Show when=move || active_scenario.get() == Some(ActiveScenario::Oversight)>
-            <OversightScenario close_signal=close_signal />
-        </Show>
-        <Show when=move || active_scenario.get() == Some(ActiveScenario::Snapshot)>
-            <SnapshotScenario close_signal=close_signal />
-        </Show>
-        <Show when=move || active_scenario.get() == Some(ActiveScenario::Resupply)>
-            <ResupplyScenario close_signal=close_signal />
-        </Show>
-        <Show when=move || active_scenario.get() == Some(ActiveScenario::DeadLetter)>
-            <DeadLetterScenario close_signal=close_signal />
-        </Show>
-        <Show when=move || active_scenario.get() == Some(ActiveScenario::Idempotency)>
-            <IdempotencyScenario close_signal=close_signal />
-        </Show>
+            // Scenario runners
+            <Show when=move || active_scenario.get() == Some(ActiveScenario::Oversight)>
+                <OversightScenario close_signal=close_signal />
+            </Show>
+            <Show when=move || active_scenario.get() == Some(ActiveScenario::Snapshot)>
+                <SnapshotScenario close_signal=close_signal />
+            </Show>
+            <Show when=move || active_scenario.get() == Some(ActiveScenario::Resupply)>
+                <ResupplyScenario close_signal=close_signal />
+            </Show>
+            <Show when=move || active_scenario.get() == Some(ActiveScenario::DeadLetter)>
+                <DeadLetterScenario close_signal=close_signal />
+            </Show>
+            <Show when=move || active_scenario.get() == Some(ActiveScenario::Idempotency)>
+                <IdempotencyScenario close_signal=close_signal />
+            </Show>
+        </div>
     }
 }

--- a/canon-demo/frontend/style/main.css
+++ b/canon-demo/frontend/style/main.css
@@ -964,3 +964,26 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .gv-badge{font-family:var(--mono);font-size:9px;padding:2px 8px;border-radius:2px;text-transform:uppercase;letter-spacing:.08em;margin-top:10px;display:inline-block;font-weight:600;}
 .gv-nr{background:rgba(245,166,35,.12);color:var(--amber);}
 .gv-rdy{background:rgba(0,229,138,.12);color:var(--green);}
+
+/* ══════════ SCENARIOS PAGE ══════════ */
+.scenarios-page{flex:1;display:flex;flex-direction:column;overflow-y:auto;background:var(--bg);transition:background .3s;}
+.sc-hero{padding:36px 40px 28px;border-bottom:1px solid var(--border);flex-shrink:0;}
+.sc-hero-title{font-family:var(--sans);font-size:26px;font-weight:700;color:var(--txthi);margin-bottom:8px;}
+.sc-hero-sub{font-family:var(--sans);font-size:15px;color:var(--txt);max-width:600px;line-height:1.6;}
+
+.sc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:18px;padding:28px 40px;}
+.sc-card{background:var(--panel);border:1px solid var(--border);padding:22px 24px;cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;position:relative;overflow:hidden;border-radius:4px;}
+.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--cyan),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
+.sc-card:hover{border-color:var(--borderhi);box-shadow:0 4px 20px var(--shadow);}
+.sc-card:hover::before{opacity:1;}
+.sc-card.active{border-color:var(--cyan);background:var(--raised);}
+.sc-card.active::before{opacity:1;}
+.sc-num{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:8px;}
+.sc-name{font-family:var(--sans);font-size:18px;font-weight:700;color:var(--txthi);margin-bottom:6px;}
+.sc-ship{font-family:var(--mono);font-size:12px;color:var(--cyan);margin-bottom:10px;}
+.sc-desc{font-family:var(--sans);font-size:13px;color:var(--txt);line-height:1.6;margin-bottom:12px;}
+.sc-tags{display:flex;flex-wrap:wrap;gap:6px;}
+.sc-tag{font-family:var(--mono);font-size:10px;padding:3px 9px;border-radius:3px;background:var(--raised);color:var(--txtlo);border:1px solid var(--border);}
+body.light .sc-tag{background:var(--bg);}
+.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--cyan);cursor:pointer;transition:all .2s;border-radius:3px;}
+.sc-launch:hover{background:rgba(0,120,180,.08);}


### PR DESCRIPTION
## Summary
- Wrapped ScenariosPage content in a single container `<div class="scenarios-page">` to fix Leptos `into_any()` fragment replacement, which was preventing the page from rendering when the tab signal changed
- Added History API integration: initial tab is read from the URL pathname on mount, tab clicks push browser history state, and a `popstate` listener handles back/forward navigation for `/scenarios`
- Added missing CSS for the scenarios page (hero section, mission card grid, card hover/active states, tags, launch buttons) matching the `reference/mockup.html` design tokens
- Added `History` and `EventTarget` web-sys features to `Cargo.toml`

Closes #175.

## Test plan
- [ ] Click "Scenarios" tab -- scenarios page renders with hero section and 5 mission cards
- [ ] Click "Live Fleet" tab -- live fleet map renders again
- [ ] Navigate directly to `/scenarios` -- scenarios page renders on load
- [ ] Use browser back/forward -- tab switches correctly
- [ ] Click a mission card -- scenario runner opens
- [ ] Verify `cargo check` passes with no errors
- [ ] Verify light/dark theme toggle works on scenarios page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)