### PR TITLE
fix(infra): correct YugabyteDB healthcheck host and credentials

### DIFF
--- a/canon-demo/docker-compose.yml
+++ b/canon-demo/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       YSQL_PASSWORD: canon
       YSQL_DB: canon
     healthcheck:
-      test: ["CMD", "bin/ysqlsh", "-U", "yugabyte", "-c", "SELECT 1"]
+      test: ["CMD-SHELL", "PGPASSWORD=canon bin/ysqlsh -h $(hostname -i) -U canon -d canon -c 'SELECT 1'"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 30
 
   cassandra:
     image: cassandra:4.1


### PR DESCRIPTION
## Summary

Fixes the YugabyteDB healthcheck in docker-compose.yml — closes #180.

## What's included

- Changed healthcheck to use `$(hostname -i)` instead of implicit localhost (postgres binds to container IP, not localhost)
- Changed user from `yugabyte` to `canon` with `PGPASSWORD=canon` (auth is enabled despite the `ysql_enable_auth=false` flag because yugabyted appends its own default)
- Increased retries from 20 to 30 (YugabyteDB is slow to start)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)