### PR TITLE
fix(docker): install cmake in gateway Dockerfile for rdkafka-sys

### DIFF
--- a/canon-demo/gateway/Dockerfile
+++ b/canon-demo/gateway/Dockerfile
@@ -1,4 +1,5 @@
 FROM rustlang/rust:nightly AS builder
+RUN apt-get update && apt-get install -y cmake build-essential && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p gateway


### PR DESCRIPTION
## Summary

Adds `cmake` and `build-essential` to the gateway Dockerfile builder stage — closes #182.

## What's included

- Added `RUN apt-get update && apt-get install -y cmake build-essential` before `cargo build`
- Gateway Docker image now builds successfully (rdkafka-sys requires cmake for librdkafka compilation)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)