### PR TITLE
fix(init-schema): add pgcrypto extension and fail on SQL errors

### DIFF
--- a/canon-demo/init-schema/init.sh
+++ b/canon-demo/init-schema/init.sh
@@ -9,6 +9,7 @@ PGPASSWORD="${YSQL_PASSWORD:-canon}" psql \
     -p "${YUGABYTE_PORT:-5433}" \
     -U "${YSQL_USER:-canon}" \
     -d "${YSQL_DB:-canon}" \
+    --set ON_ERROR_STOP=1 \
     -f /schema/yugabyte.sql
 echo "==> YugabyteDB schema ready."
 

--- a/canon-demo/init-schema/yugabyte.sql
+++ b/canon-demo/init-schema/yugabyte.sql
@@ -1,6 +1,9 @@
 -- Canon YugabyteDB schema initialisation
 -- Runs as an init container before services start.
 
+-- pgcrypto provides gen_random_uuid() used by inbox_windows, outbox, and dead_letters
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- inbox
 CREATE TABLE IF NOT EXISTS inbox_messages (
     handler_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Fixes init-schema to create the `pgcrypto` extension before table creation -- closes #181.

- Added `CREATE EXTENSION IF NOT EXISTS pgcrypto;` at the top of `yugabyte.sql`
- Added `--set ON_ERROR_STOP=1` to the `psql` invocation in `init.sh` so SQL errors cause a non-zero exit code (the existing `set -euo pipefail` then halts the script)
- All 10 tables now create successfully (previously `inbox_windows`, `outbox`, `dead_letters` failed silently because `gen_random_uuid()` was undefined)

## Why `ON_ERROR_STOP`?

`set -e` in bash catches non-zero exit codes, but `psql -f` returns 0 even when individual SQL statements fail -- unless `ON_ERROR_STOP=1` is set. Without this flag the container would still exit 0 on future schema errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)