### PR TITLE
fix(init-schema): add station_inventory projection table

### DIFF
--- a/canon-demo/init-schema/yugabyte.sql
+++ b/canon-demo/init-schema/yugabyte.sql
@@ -90,6 +90,17 @@ CREATE TABLE IF NOT EXISTS projections (
     PRIMARY KEY (projection_id, aggregate_id)
 );
 
+-- station inventory projection (read-ready materialised view)
+CREATE TABLE IF NOT EXISTS station_inventory (
+    station_id       UUID PRIMARY KEY,
+    name             TEXT NOT NULL,
+    capacity_kg      REAL NOT NULL DEFAULT 0,
+    current_stock_kg REAL NOT NULL DEFAULT 0,
+    last_docking     TIMESTAMPTZ,
+    offline          BOOLEAN NOT NULL DEFAULT false,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 -- dead letters
 CREATE TABLE IF NOT EXISTS dead_letters (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary

- Adds the missing `station_inventory` projection table to `canon-demo/init-schema/yugabyte.sql` — closes #184
- The gateway's `GET /stations` and `GET /stations/:id/inventory` endpoints query this table via `sqlx::query_as`, which fails with "relation does not exist" without it
- Column types use `REAL` (not `INT`) to match the Rust `f32` fields in `StationInventoryResponse` and `StationInventoryRow`

## Test plan

- [ ] Verify `canon-demo/init-schema/yugabyte.sql` creates the `station_inventory` table on a fresh YugabyteDB instance
- [ ] Confirm `GET /stations` and `GET /stations/:id/inventory` no longer return relation-not-found errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)