### PR TITLE
fix(docker): add sequential build script and CARGO_BUILD_JOBS=1 to prevent OOM

### DIFF
--- a/canon-demo/README.md
+++ b/canon-demo/README.md
@@ -1,0 +1,40 @@
+# Canon Demo
+
+Multi-service event-sourcing demo built on the Canon framework.
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| fleet-service | - | Ship aggregate (register, depart, resupply) |
+| cargo-service | - | Manifest aggregate (load, unload cargo) |
+| navigation-service | - | Route aggregate (plan, track positions) |
+| station-service | - | Station aggregate (docking, stock levels) |
+| supply-service | - | Inventory aggregate (resupply lifecycle) |
+| gateway | 8080 | REST + WebSocket API |
+| frontend | 3000 | Leptos WASM UI |
+
+## Infrastructure
+
+- **YugabyteDB** (5433) -- command store, outbox, snapshots, projections, inbox
+- **Cassandra** (9042) -- event store
+- **Kafka** (9092/9093) -- message queues
+
+## Building
+
+### Option 1: Sequential Docker builds (recommended)
+
+```bash
+./scripts/build-images.sh
+docker compose up -d
+```
+
+### Option 2: Direct compose (requires 16+ GiB Docker memory)
+
+```bash
+docker compose up -d
+```
+
+**Note:** Docker Desktop defaults to 8 GiB RAM. Building all 7 Rust services
+in parallel requires 16+ GiB. Use `scripts/build-images.sh` or set
+`COMPOSE_PARALLEL_LIMIT=1` to build sequentially.

--- a/canon-demo/cargo-service/Dockerfile
+++ b/canon-demo/cargo-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p cargo-service
 
 FROM debian:bookworm-slim

--- a/canon-demo/fleet-service/Dockerfile
+++ b/canon-demo/fleet-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p fleet-service
 
 FROM debian:bookworm-slim

--- a/canon-demo/gateway/Dockerfile
+++ b/canon-demo/gateway/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p gateway
 
 FROM debian:bookworm-slim

--- a/canon-demo/navigation-service/Dockerfile
+++ b/canon-demo/navigation-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p navigation-service
 
 FROM debian:bookworm-slim

--- a/canon-demo/scripts/build-images.sh
+++ b/canon-demo/scripts/build-images.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Build all Canon demo Docker images sequentially to avoid OOM.
+# Docker Desktop default memory (8 GiB) is not enough for parallel Rust builds.
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "Building Canon demo images sequentially..."
+for svc in fleet-service cargo-service navigation-service station-service supply-service gateway frontend; do
+  echo "==> Building $svc..."
+  COMPOSE_PARALLEL_LIMIT=1 docker compose build "$svc"
+  echo "==> $svc built."
+done
+
+echo "All images built successfully."

--- a/canon-demo/station-service/Dockerfile
+++ b/canon-demo/station-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p station-service
 
 FROM debian:bookworm-slim

--- a/canon-demo/supply-service/Dockerfile
+++ b/canon-demo/supply-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM rustlang/rust:nightly AS builder
 WORKDIR /build
 COPY . .
+ENV CARGO_BUILD_JOBS=1
 RUN cargo build --release -p supply-service
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

Prevents OOM during Docker image builds -- closes #183.

- Added `ENV CARGO_BUILD_JOBS=1` to all 6 Rust service Dockerfiles to reduce per-build memory usage
- Added `scripts/build-images.sh` -- builds all images sequentially with `COMPOSE_PARALLEL_LIMIT=1`
- Added `canon-demo/README.md` with build instructions and Docker memory requirements

## Test plan

- [ ] Run `./scripts/build-images.sh` on Docker Desktop with 8 GiB RAM -- all images build without OOM
- [ ] Run `docker compose up -d` after images are built -- all services start
- [ ] Verify `CARGO_BUILD_JOBS=1` is present in each Rust Dockerfile's builder stage

🤖 Generated with [Claude Code](https://claude.ai/claude-code)