### PR TITLE
fix(infra): pre-create Kafka event topics in init-schema

### DIFF
--- a/canon-demo/docker-compose.yml
+++ b/canon-demo/docker-compose.yml
@@ -82,6 +82,8 @@ services:
         condition: service_healthy
       cassandra:
         condition: service_healthy
+      kafka:
+        condition: service_healthy
     environment:
       YUGABYTE_HOST: yugabytedb
       YUGABYTE_PORT: "5433"
@@ -90,6 +92,8 @@ services:
       YSQL_DB: canon
       CASSANDRA_HOST: cassandra
       CASSANDRA_PORT: "9042"
+      KAFKA_HOST: kafka
+      KAFKA_PORT: "9092"
 
   # ── Demo services ──────────────────────────────────────────────────────
   fleet-service:

--- a/canon-demo/init-schema/Dockerfile
+++ b/canon-demo/init-schema/Dockerfile
@@ -1,9 +1,19 @@
 FROM cassandra:4.1
 
 # Install PostgreSQL client for YugabyteDB schema init
+# and download Kafka CLI tools for topic pre-creation
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client && \
+    apt-get install -y --no-install-recommends postgresql-client curl && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and extract Kafka CLI tools (kafka-topics.sh)
+ENV KAFKA_VERSION=3.7.1
+ENV SCALA_VERSION=2.13
+RUN curl -sL "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+    | tar -xz -C /opt && \
+    ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka
+
+ENV PATH="/opt/kafka/bin:${PATH}"
 
 COPY init.sh /init.sh
 COPY yugabyte.sql /schema/yugabyte.sql

--- a/canon-demo/init-schema/init.sh
+++ b/canon-demo/init-schema/init.sh
@@ -17,4 +17,16 @@ cqlsh "${CASSANDRA_HOST:-cassandra}" "${CASSANDRA_PORT:-9042}" \
     -f /schema/cassandra.cql
 echo "==> Cassandra schema ready."
 
+echo "==> Creating Kafka topics..."
+KAFKA_BOOTSTRAP="${KAFKA_HOST:-kafka}:${KAFKA_PORT:-9092}"
+for topic in canon.fleet.events canon.cargo.events canon.navigation.events canon.supply.events canon.station.events; do
+    kafka-topics.sh --bootstrap-server "$KAFKA_BOOTSTRAP" \
+        --create --if-not-exists \
+        --topic "$topic" \
+        --partitions 3 \
+        --replication-factor 1
+    echo "    created topic: $topic"
+done
+echo "==> Kafka topics ready."
+
 echo "==> All schemas initialised."


### PR DESCRIPTION
## Summary

- Pre-creates the 5 Kafka event topics (`canon.fleet.events`, `canon.cargo.events`, `canon.navigation.events`, `canon.supply.events`, `canon.station.events`) during init-schema, before any service starts
- Adds Kafka CLI tools (`kafka-topics.sh`) to the init-schema Docker image via the Apache Kafka 3.7.1 distribution (the `cassandra:4.1` base image already has Java)
- Adds `kafka` as a `depends_on` (with `service_healthy` condition) for init-schema in docker-compose.yml
- Gateway consumers no longer log `UnknownTopicOrPartition` errors on startup; frontend Kafka infra status dot shows green immediately

Closes #185.

## Test plan

- [ ] `docker compose build init-schema` succeeds (Kafka tools download correctly)
- [ ] `docker compose up` brings up all services; init-schema logs show all 5 topics created
- [ ] Gateway starts without `UnknownTopicOrPartition` errors
- [ ] Frontend header shows Kafka status as green on first load

🤖 Generated with [Claude Code](https://claude.ai/claude-code)