### PR TITLE
feat(build): drop rdkafka cmake-build feature for cross-compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 tracing = "0.1"
-rdkafka = { version = "0.36", features = ["cmake-build"] }
+rdkafka = { version = "0.36" }
 base64 = "0.22"

--- a/canon-adaptor-kafka/Cargo.toml
+++ b/canon-adaptor-kafka/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = "0.1"
-rdkafka = { version = "0.36", features = ["cmake-build"] }
+rdkafka = { version = "0.36" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/canon-outbound-queue-kafka/Cargo.toml
+++ b/canon-outbound-queue-kafka/Cargo.toml
@@ -15,7 +15,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-rdkafka = { version = "0.36", features = ["cmake-build"] }
+rdkafka = { version = "0.36" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/canon-publisher-kafka/Cargo.toml
+++ b/canon-publisher-kafka/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-rdkafka = { version = "0.36", features = ["cmake-build"] }
+rdkafka = { version = "0.36" }
 
 [dev-dependencies]
 bytes = { workspace = true }


### PR DESCRIPTION
## Summary

- Removed the `cmake-build` feature from all `rdkafka` dependencies across the workspace, switching to the default `cc`-crate build path
- Updated 4 files: workspace root `Cargo.toml`, `canon-adaptor-kafka/Cargo.toml`, `canon-outbound-queue-kafka/Cargo.toml`, `canon-publisher-kafka/Cargo.toml`
- `canon-inbound-queue-kafka` and `gateway` already used `{ workspace = true }` and inherit the change automatically

## Why

The `cmake-build` feature compiles librdkafka via cmake, which:
1. Requires cmake installed in Docker images (#182)
2. Fails under `cargo zigbuild` cross-compilation because cmake cannot find the cross toolchain

Without `cmake-build`, `rdkafka-sys` builds librdkafka via the `cc` crate, which respects the `CC` env var that `cargo zigbuild` sets automatically. This unblocks #186 (zigbuild cross-compilation workflow).

## Test plan

- [x] `cargo check -p gateway` passes
- [x] `cargo check -p canon-adaptor-kafka` passes
- [x] `cargo check -p canon-outbound-queue-kafka` passes
- [x] `cargo check -p canon-publisher-kafka` passes
- [x] No remaining references to `cmake-build` or `cmake_build` in any `Cargo.toml`

## Related
- Closes #187
- #186 — cargo-zigbuild cross-compilation (unblocked by this change)
- #182 — gateway Dockerfile missing cmake (becomes less critical)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)