### PR TITLE
fix(infra): use cp-kafka container for Kafka topic pre-creation

### DIFF
--- a/canon-demo/docker-compose.yml
+++ b/canon-demo/docker-compose.yml
@@ -82,8 +82,6 @@ services:
         condition: service_healthy
       cassandra:
         condition: service_healthy
-      kafka:
-        condition: service_healthy
     environment:
       YUGABYTE_HOST: yugabytedb
       YUGABYTE_PORT: "5433"
@@ -92,8 +90,23 @@ services:
       YSQL_DB: canon
       CASSANDRA_HOST: cassandra
       CASSANDRA_PORT: "9042"
-      KAFKA_HOST: kafka
-      KAFKA_PORT: "9092"
+
+  init-kafka-topics:
+    image: confluentinc/cp-kafka:7.7.1
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      echo '==> Creating Kafka topics...'
+      for topic in canon.fleet.events canon.cargo.events canon.navigation.events canon.supply.events canon.station.events; do
+        kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic $$topic --partitions 3 --replication-factor 1
+        echo \"    created topic: $$topic\"
+      done
+      echo '==> Kafka topics ready.'
+      "
+    restart: "no"
 
   # ── Demo services ──────────────────────────────────────────────────────
   fleet-service:
@@ -102,6 +115,8 @@ services:
       dockerfile: canon-demo/fleet-service/Dockerfile
     depends_on:
       init-schema:
+        condition: service_completed_successfully
+      init-kafka-topics:
         condition: service_completed_successfully
       kafka:
         condition: service_healthy
@@ -118,6 +133,8 @@ services:
     depends_on:
       init-schema:
         condition: service_completed_successfully
+      init-kafka-topics:
+        condition: service_completed_successfully
       kafka:
         condition: service_healthy
     environment:
@@ -132,6 +149,8 @@ services:
       dockerfile: canon-demo/navigation-service/Dockerfile
     depends_on:
       init-schema:
+        condition: service_completed_successfully
+      init-kafka-topics:
         condition: service_completed_successfully
       kafka:
         condition: service_healthy
@@ -148,6 +167,8 @@ services:
     depends_on:
       init-schema:
         condition: service_completed_successfully
+      init-kafka-topics:
+        condition: service_completed_successfully
       kafka:
         condition: service_healthy
     environment:
@@ -163,6 +184,8 @@ services:
     depends_on:
       init-schema:
         condition: service_completed_successfully
+      init-kafka-topics:
+        condition: service_completed_successfully
       kafka:
         condition: service_healthy
     environment:
@@ -177,6 +200,8 @@ services:
       dockerfile: canon-demo/gateway/Dockerfile
     depends_on:
       init-schema:
+        condition: service_completed_successfully
+      init-kafka-topics:
         condition: service_completed_successfully
       kafka:
         condition: service_healthy

--- a/canon-demo/init-schema/Dockerfile
+++ b/canon-demo/init-schema/Dockerfile
@@ -1,19 +1,9 @@
 FROM cassandra:4.1
 
 # Install PostgreSQL client for YugabyteDB schema init
-# and download Kafka CLI tools for topic pre-creation
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client curl && \
+    apt-get install -y --no-install-recommends postgresql-client && \
     rm -rf /var/lib/apt/lists/*
-
-# Download and extract Kafka CLI tools (kafka-topics.sh)
-ENV KAFKA_VERSION=3.7.1
-ENV SCALA_VERSION=2.13
-RUN curl -sL "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
-    | tar -xz -C /opt && \
-    ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka
-
-ENV PATH="/opt/kafka/bin:${PATH}"
 
 COPY init.sh /init.sh
 COPY yugabyte.sql /schema/yugabyte.sql

--- a/canon-demo/init-schema/init.sh
+++ b/canon-demo/init-schema/init.sh
@@ -18,16 +18,4 @@ cqlsh "${CASSANDRA_HOST:-cassandra}" "${CASSANDRA_PORT:-9042}" \
     -f /schema/cassandra.cql
 echo "==> Cassandra schema ready."
 
-echo "==> Creating Kafka topics..."
-KAFKA_BOOTSTRAP="${KAFKA_HOST:-kafka}:${KAFKA_PORT:-9092}"
-for topic in canon.fleet.events canon.cargo.events canon.navigation.events canon.supply.events canon.station.events; do
-    kafka-topics.sh --bootstrap-server "$KAFKA_BOOTSTRAP" \
-        --create --if-not-exists \
-        --topic "$topic" \
-        --partitions 3 \
-        --replication-factor 1
-    echo "    created topic: $topic"
-done
-echo "==> Kafka topics ready."
-
 echo "==> All schemas initialised."


### PR DESCRIPTION
## Summary

Fixes Kafka topic pre-creation by using a separate `confluentinc/cp-kafka:7.7.1` init container instead of downloading Kafka tools — closes #195.

## What's included

- Removed Kafka download and topic creation from init-schema (reverts broken parts of PR #193)
- Added `init-kafka-topics` service in docker-compose.yml using the existing cp-kafka image
- Pre-creates all 5 event topics (canon.fleet/cargo/navigation/supply/station.events)
- All demo services depend on both init-schema and init-kafka-topics completing
- No external downloads required during build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)