### PR TITLE
feat(frontend): move event log to horizontal strip at bottom

### DIFF
--- a/canon-demo/frontend/src/pages/live_fleet.rs
+++ b/canon-demo/frontend/src/pages/live_fleet.rs
@@ -365,7 +365,7 @@ pub fn LiveFleetPage(state: AppState) -> impl IntoView {
                 <MapBar ships=state.ships />
                 <MapCanvas state=state />
             </div>
-            <Sidebar state=state />
+            <EventLogStrip state=state />
         </div>
     }
 }
@@ -842,7 +842,7 @@ fn OversightStrip(oversight: RwSignal<OversightState>) -> impl IntoView {
 }
 
 #[component]
-fn Sidebar(state: AppState) -> impl IntoView {
+fn EventLogStrip(state: AppState) -> impl IntoView {
     let entries = state.log_entries;
     let highlighted = state.highlighted_corr;
 
@@ -860,12 +860,12 @@ fn Sidebar(state: AppState) -> impl IntoView {
     };
 
     view! {
-        <div class="sidebar">
-            <div class="sidebar-header">
-                <span class="pulse-dot"></span>
-                "Live Activity"
+        <div class="event-log-strip">
+            <div class="log-header">
+                <span class="bar-lbl">"Event log"</span>
+                <div class="live-badge"><div class="dot"></div>"Live"</div>
             </div>
-            <div class="event-log">
+            <div class="log-body">
                 <For
                     each=move || entries.get()
                     key=|entry| entry.id
@@ -874,7 +874,7 @@ fn Sidebar(state: AppState) -> impl IntoView {
                     }
                 />
             </div>
-            <div class="sidebar-footer">
+            <div class="log-footer">
                 "Click any event to trace its correlation chain "
                 <a on:click=highlight_random>"(highlight random)"</a>
             </div>
@@ -888,23 +888,23 @@ fn LogEntryRow(entry: LogEntry, highlighted: RwSignal<Option<Uuid>>) -> impl Int
     let is_highlighted = move || highlighted.get() == Some(corr_id);
 
     let row_class = move || {
-        let mut cls = "log-entry".to_string();
+        let mut cls = "log-item".to_string();
         if entry.is_new {
-            cls.push_str(" flash");
+            cls.push_str(" fresh");
         }
         if is_highlighted() {
-            cls.push_str(" corr-highlight");
+            cls.push_str(" lit");
         }
         cls
     };
 
-    let badge_class = match entry.service.as_str() {
-        "fleet" => "service-badge fleet",
-        "cargo" => "service-badge cargo",
-        "nav" => "service-badge nav",
-        "supply" => "service-badge supply",
-        "station" => "service-badge station",
-        _ => "service-badge",
+    let svc_class = match entry.service.as_str() {
+        "fleet" => "svc sf",
+        "cargo" => "svc sc",
+        "nav" => "svc sn",
+        "supply" => "svc su",
+        "station" => "svc ss",
+        _ => "svc",
     };
 
     let agg_short = format!("{}...", &entry.aggregate_id.to_string()[..8]);
@@ -920,15 +920,12 @@ fn LogEntryRow(entry: LogEntry, highlighted: RwSignal<Option<Uuid>>) -> impl Int
 
     view! {
         <div class=row_class on:click=on_click>
-            <div class="log-entry-meta">
-                <span>{entry.timestamp.clone()}</span>
-                <span>{format!("v{}", entry.version)}</span>
+            <span class="log-ts">{entry.timestamp.clone()}</span>
+            <div class="log-row">
+                <span class=svc_class>{entry.service.clone()}</span>
+                <span class="log-name">{entry.event_name.clone()}</span>
+                <span class="log-agg">{agg_short}</span>
             </div>
-            <div class="log-entry-body">
-                <span class=badge_class>{entry.service.clone()}</span>
-                <span class="log-event-name">{entry.event_name.clone()}</span>
-            </div>
-            <div class="log-agg-id">{agg_short}</div>
         </div>
     }
 }

--- a/canon-demo/frontend/src/ws.rs
+++ b/canon-demo/frontend/src/ws.rs
@@ -17,7 +17,7 @@ use crate::state::{
     OversightReqStatus, ShipStatus, WsMessage,
 };
 
-/// Maximum number of log entries to keep in the sidebar.
+/// Maximum number of log entries to keep in the event log strip.
 const MAX_LOG_ENTRIES: usize = 60;
 
 /// Maximum backoff delay in milliseconds.

--- a/canon-demo/frontend/style/main.css
+++ b/canon-demo/frontend/style/main.css
@@ -229,6 +229,7 @@ body.light::before { opacity: 0; }
 /* ===== Content area ===== */
 .content-area {
   display: flex;
+  flex-direction: column;
   flex: 1;
   overflow: hidden;
   position: relative;
@@ -555,31 +556,35 @@ body.light::before { opacity: 0; }
   background: rgba(0,229,138,.08);
 }
 
-/* ===== Sidebar ===== */
-.sidebar {
-  width: 280px;
-  background: var(--panel);
-  border-left: 1px solid var(--border);
+/* ===== Event Log Strip ===== */
+.event-log-strip {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
 }
 
-.sidebar-header {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--divclr);
-  font-family: var(--sans);
-  font-weight: 700;
-  font-size: 12px;
-  color: var(--txthi);
-  text-transform: uppercase;
-  letter-spacing: 1px;
+.log-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  padding: 8px 20px;
+  border-bottom: 1px solid var(--divclr);
+  background: var(--panel);
+  flex-shrink: 0;
 }
 
-.sidebar-header .pulse-dot {
+.live-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--greendim);
+}
+
+.live-badge .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -593,108 +598,125 @@ body.light::before { opacity: 0; }
   50% { opacity: 0.4; }
 }
 
-.event-log {
-  flex: 1;
+.log-body {
   overflow-y: auto;
-  padding: 6px 0;
+  max-height: 160px;
+  padding: 0;
+  background: var(--panel);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
-.event-log::-webkit-scrollbar {
+.log-body::-webkit-scrollbar {
   width: 4px;
 }
-.event-log::-webkit-scrollbar-track {
+.log-body::-webkit-scrollbar-track {
   background: transparent;
 }
-.event-log::-webkit-scrollbar-thumb {
+.log-body::-webkit-scrollbar-thumb {
   background: var(--border);
   border-radius: 2px;
 }
 
-.log-entry {
-  padding: 6px 14px;
-  border-left: 2px solid transparent;
-  transition: background .2s, border-color .2s;
+.log-item {
+  padding: 7px 20px;
+  border-left: 3px solid transparent;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--divclr);
+  transition: background .12s, border-color .12s;
 }
 
-.log-entry:hover {
+.log-item:hover {
   background: var(--logbg);
 }
 
-.log-entry.corr-highlight {
-  border-left-color: var(--cyan);
+.log-item.lit {
   background: var(--loglit);
+  border-left-color: var(--cyan);
 }
 
-.log-entry.flash {
-  animation: flash 0.6s ease-out;
+.log-item.fresh {
+  animation: flash .5s ease-out;
 }
 
 @keyframes flash {
-  from { background: rgba(0,180,255,.22); }
-  to { background: transparent; }
+  0% { background: rgba(0,180,255,.22); }
+  100% { background: transparent; }
 }
 
-.log-entry-meta {
+.log-ts {
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 11px;
   color: var(--txtlo);
-  margin-bottom: 2px;
-  display: flex;
-  gap: 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
-.log-entry-body {
+.log-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
+  flex: 1;
+  min-width: 0;
 }
 
-.service-badge {
-  font-family: var(--mono);
-  font-size: 8px;
-  padding: 1px 6px;
-  border-radius: 3px;
+.log-name {
+  font-family: var(--sans);
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: var(--txthi);
   white-space: nowrap;
 }
 
-.service-badge.fleet   { color: var(--cyan);   border: 1px solid var(--cyandim);  background: rgba(0,180,255,.08); }
-.service-badge.cargo   { color: var(--purple); border: 1px solid rgba(167,139,250,.4); background: rgba(167,139,250,.08); }
-.service-badge.nav     { color: var(--green);  border: 1px solid var(--greendim); background: rgba(0,229,138,.08); }
-.service-badge.supply  { color: var(--red);    border: 1px solid var(--reddim);   background: rgba(255,64,105,.08); }
-.service-badge.station { color: var(--amber);  border: 1px solid var(--amberdim); background: rgba(245,166,35,.08); }
-
-.log-event-name {
-  font-family: var(--body);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--txthi);
-}
-
-.log-agg-id {
+.log-agg {
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 11px;
   color: var(--txtlo);
-  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
 }
 
-.sidebar-footer {
-  padding: 10px 14px;
+/* Service badges */
+.svc {
+  font-family: var(--sans);
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.sf { background: rgba(0,180,255,.12); color: var(--cyan); }
+.sc { background: rgba(167,139,250,.14); color: var(--purple); }
+.sn { background: rgba(0,229,138,.11); color: var(--green); }
+.ss { background: rgba(245,166,35,.12); color: var(--amber); }
+.su { background: rgba(255,64,105,.11); color: var(--red); }
+
+body.light .sf { background: rgba(0,120,180,.12); color: #005fa8; }
+body.light .sc { background: rgba(124,58,237,.12); color: #5b21b6; }
+body.light .sn { background: rgba(0,168,107,.12); color: #00694a; }
+body.light .ss { background: rgba(212,130,10,.12); color: #92570a; }
+body.light .su { background: rgba(212,46,85,.12); color: #991b3d; }
+
+.log-footer {
+  padding: 8px 20px;
   border-top: 1px solid var(--divclr);
   font-family: var(--mono);
   font-size: 9px;
   color: var(--txtlo);
 }
 
-.sidebar-footer a {
+.log-footer a {
   color: var(--cyandim);
   text-decoration: none;
   cursor: pointer;
 }
-.sidebar-footer a:hover {
+.log-footer a:hover {
   color: var(--cyan);
 }
 
@@ -810,19 +832,17 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .sc-sub-btn:hover{border-color:var(--borderhi);color:var(--txthi);}
 
 /* ══════════ SCENARIO LOG ITEMS ══════════ */
-.log-item{padding:6px 14px;border-left:2px solid transparent;cursor:pointer;transition:background .12s,border-color .12s;}
-.log-item:hover{background:var(--logbg);}
-.log-item.lit{background:var(--loglit);border-left-color:var(--cyan);}
-.log-item.lit.orig{background:var(--logorig);}
-.log-item.fresh{animation:flash .6s ease-out;}
-.log-ts{font-family:var(--mono);font-size:9px;color:var(--txtlo);margin-bottom:2px;}
-.log-row{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}
-.log-name{font-family:var(--body);font-size:11px;font-weight:600;color:var(--txthi);}
-.log-agg{font-family:var(--mono);font-size:9px;color:var(--txtlo);margin-top:1px;}
+.sc-log-inner .log-item{padding:6px 14px;border-left:2px solid transparent;cursor:pointer;transition:background .12s,border-color .12s;}
+.sc-log-inner .log-item:hover{background:var(--logbg);}
+.sc-log-inner .log-item.lit{background:var(--loglit);border-left-color:var(--cyan);}
+.sc-log-inner .log-item.lit.orig{background:var(--logorig);}
+.sc-log-inner .log-item.fresh{animation:flash .6s ease-out;}
+.sc-log-inner .log-ts{font-family:var(--mono);font-size:9px;color:var(--txtlo);margin-bottom:2px;}
+.sc-log-inner .log-row{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}
+.sc-log-inner .log-name{font-family:var(--body);font-size:11px;font-weight:600;color:var(--txthi);}
+.sc-log-inner .log-agg{font-family:var(--mono);font-size:9px;color:var(--txtlo);margin-top:1px;}
 .log-div{height:1px;background:var(--divclr);margin:0 12px;}
 .sb-bar{display:flex;align-items:center;justify-content:space-between;padding:9px 16px;border-bottom:1px solid var(--border);flex-shrink:0;transition:border-color .3s;}
-.live-badge{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:9px;color:var(--greendim);}
-.live-badge .dot{width:5px;height:5px;}
 
 /* ══════════ HYDRATION VIZ (Mission 02) ══════════ */
 .hydrate-viz{width:100%;max-width:400px;text-align:center;}


### PR DESCRIPTION
## Summary

Replaces the right sidebar event log with a horizontal strip at the bottom — closes #203.

## What's included

- Event log rendered as horizontal strip (max-height 160px, scrollable)
- Each entry: timestamp · service badge · event name · aggregate text
- Service badges color-coded (fleet=cyan, cargo=purple, nav=green, station=amber, supply=red)
- Flash animation on new events
- Correlation chain click-to-highlight
- Removed right sidebar
- Full-width vertical column layout

🤖 Generated with [Claude Code](https://claude.ai/claude-code)