### PR TITLE
chore(ci): speed up CI with dependency caching and parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
+  clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo check --workspace
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace


### PR DESCRIPTION
## Summary

CI takes ~5 min because it downloads and compiles all dependencies from scratch every run, and runs check/clippy/test sequentially. This PR fixes both problems.

## Changes

- Add `Swatinem/rust-cache@v2` to cache compiled dependencies between runs
- Drop redundant `cargo check --workspace` (clippy is a strict superset)
- Split clippy and test into two parallel jobs

## Expected impact

- **First run**: unchanged (~5 min)
- **Subsequent runs**: ~2 min (cached deps, only recompile changed crates)
- **Wall-clock**: clippy and test run concurrently, so total time is the slower of the two rather than both summed

🤖 Generated with [Claude Code](https://claude.com/claude-code)