### PR TITLE
fix(build): fix gateway Docker GLIBC crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codee"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2369,7 @@ version = "4.10.0+2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
 dependencies = [
+ "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 tracing = "0.1"
-rdkafka = { version = "0.36" }
+rdkafka = { version = "0.36", features = ["cmake-build"] }
 base64 = "0.22"

--- a/canon-adaptor-kafka/Cargo.toml
+++ b/canon-adaptor-kafka/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = "0.1"
-rdkafka = { version = "0.36" }
+rdkafka = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/canon-outbound-queue-kafka/Cargo.toml
+++ b/canon-outbound-queue-kafka/Cargo.toml
@@ -15,7 +15,7 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-rdkafka = { version = "0.36" }
+rdkafka = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/canon-publisher-kafka/Cargo.toml
+++ b/canon-publisher-kafka/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-rdkafka = { version = "0.36" }
+rdkafka = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }


### PR DESCRIPTION
## Summary

Fixes the gateway Docker container crash (`GLIBC_2.38 not found`) — closes #228.

## What's included

- Enable `cmake-build` feature on `rdkafka` in the workspace dependency, so that `rdkafka-sys` builds `librdkafka` via CMake instead of the default make-based build. CMake correctly picks up zig's CC/CXX cross-compilation wrappers that `cargo zigbuild` sets up, producing a binary linked against the older GLIBC available in `debian:bookworm-slim`.
- Standardise 3 Kafka infrastructure crates (`canon-publisher-kafka`, `canon-outbound-queue-kafka`, `canon-adaptor-kafka`) to use `rdkafka = { workspace = true }` instead of inline `{ version = "0.36" }`, so all crates consistently get the `cmake-build` feature.

## Root cause

The 5 domain services cross-compile fine because they don't depend on `rdkafka`. The gateway does depend on `rdkafka`, whose C dependency (`librdkafka`) failed to cross-compile with zigbuild's default make-based build. The fallback host-compiled binary required GLIBC 2.38, but `debian:bookworm-slim` only provides 2.36.

## Canon rules compliance

- [x] No `unwrap()`/`expect()` in library code
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)