### PR TITLE
feat(commands): merge fix-prs into review-prs

### DIFF
--- a/.claude/commands/review-prs.md
+++ b/.claude/commands/review-prs.md
@@ -1,11 +1,11 @@
-# review-prs — Canon PR review and fix agent
+# review-prs — Canon PR review, fix, and health agent
 
 You are the Canon PR review orchestrator. Your job is to:
 
-1. Discover all open PRs
+1. Discover all open PRs (review state, merge conflicts, CI status)
 2. For each PR, check whether it has already been reviewed by this command
 3. Spawn parallel review agents — one per unreviewed (or changed) PR
-4. Each agent reviews the PR, posts inline GitHub comments, applies all fixes, and commits
+4. Each agent fixes merge conflicts, fixes CI failures, reviews the PR, posts inline GitHub comments, applies all fixes, and commits
 
 Read `CLAUDE.md` before doing anything else:
 ```bash
@@ -17,15 +17,15 @@ cat CLAUDE.md
 ## Phase 0 — Discover open PRs and their review state
 
 ```bash
-# Get all open PRs with metadata
+# Get all open PRs with metadata, merge status, and CI status
 gh pr list --state open --limit 100 \
-  --json number,title,headRefName,headRefOid,body,comments \
+  --json number,title,headRefName,headRefOid,body,comments,mergeable,mergeStateStatus,statusCheckRollup \
   > /tmp/open_prs.json
 
 cat /tmp/open_prs.json
 ```
 
-For each PR, check whether a `review-prs` bot comment already exists:
+For each PR, check whether a `review-prs` bot comment already exists, and report merge conflict / CI status:
 
 ```bash
 python3 << 'EOF'
@@ -39,6 +39,22 @@ already_reviewed = []
 
 for pr in prs:
     num = pr['number']
+    merge = pr.get('mergeable', 'UNKNOWN')          # MERGEABLE | CONFLICTING | UNKNOWN
+    state = pr.get('mergeStateStatus', 'UNKNOWN')   # CLEAN | DIRTY | BLOCKED | BEHIND | UNKNOWN
+
+    # Collect failing checks
+    checks      = pr.get('statusCheckRollup') or []
+    failing     = [c for c in checks if c.get('conclusion') in ('FAILURE', 'ERROR', 'TIMED_OUT')]
+    check_names = [c.get('name', c.get('context', '?')) for c in failing]
+
+    has_conflict = merge == 'CONFLICTING'
+    has_failures = bool(failing)
+
+    health_notes = []
+    if has_conflict:  health_notes.append('CONFLICT')
+    if has_failures:  health_notes.append('CI:' + ','.join(check_names))
+    health_str = ' | '.join(health_notes) if health_notes else 'healthy'
+
     # Fetch all comments on this PR
     result = subprocess.run(
         ['gh', 'pr', 'view', str(num), '--json', 'comments', '--jq', '.comments[].body'],
@@ -51,29 +67,38 @@ for pr in prs:
         if review_lines:
             last_sha = review_lines[-1].split('review-prs-sha:')[-1].strip()
             current_sha = pr['headRefOid']
-            if last_sha == current_sha:
-                already_reviewed.append((num, pr['title'], 'no new commits'))
+            if last_sha == current_sha and not has_conflict and not has_failures:
+                already_reviewed.append((num, pr['title'], 'no new commits, healthy'))
             else:
+                reason_parts = []
+                if last_sha != current_sha:
+                    reason_parts.append(f're-review: HEAD changed {last_sha[:7]}→{current_sha[:7]}')
+                if has_conflict or has_failures:
+                    reason_parts.append(health_str)
                 needs_review.append((num, pr['title'], pr['headRefName'], current_sha,
-                                     f're-review: HEAD changed {last_sha[:7]}→{current_sha[:7]}'))
+                                     ' + '.join(reason_parts) if reason_parts else 'initial review',
+                                     has_conflict, check_names))
         else:
-            needs_review.append((num, pr['title'], pr['headRefName'], pr['headRefOid'], 'initial review'))
+            needs_review.append((num, pr['title'], pr['headRefName'], pr['headRefOid'],
+                                 f'initial review ({health_str})', has_conflict, check_names))
     else:
-        needs_review.append((num, pr['title'], pr['headRefName'], pr['headRefOid'], 'initial review'))
+        needs_review.append((num, pr['title'], pr['headRefName'], pr['headRefOid'],
+                             f'initial review ({health_str})', has_conflict, check_names))
 
-print("=== SKIPPING (already reviewed, no new commits) ===")
+print("=== SKIPPING (already reviewed, no new commits, healthy) ===")
 for num, title, reason in already_reviewed:
     print(f"  PR #{num}: {title} — {reason}")
 
 print("\n=== WILL REVIEW ===")
-for num, title, branch, sha, reason in needs_review:
+for num, title, branch, sha, reason, conflict, ci_fails in needs_review:
     print(f"  PR #{num}: {title} [{branch}] @ {sha[:7]} — {reason}")
 
 # Write the work list
 with open('/tmp/prs_to_review.json', 'w') as f:
     json.dump([
-        {'number': num, 'title': title, 'branch': branch, 'sha': sha, 'reason': reason}
-        for num, title, branch, sha, reason in needs_review
+        {'number': num, 'title': title, 'branch': branch, 'sha': sha, 'reason': reason,
+         'has_conflict': conflict, 'failing_checks': ci_fails}
+        for num, title, branch, sha, reason, conflict, ci_fails in needs_review
     ], f, indent=2)
 
 print(f"\n{len(needs_review)} PRs to review, {len(already_reviewed)} skipped.")
@@ -95,13 +120,19 @@ import json, subprocess, os
 prs = json.load(open('/tmp/prs_to_review.json'))
 
 AGENT_PROMPT_TEMPLATE = """
-You are a Canon PR review and fix agent. You are responsible for PR #{number} ({title}).
+You are a Canon PR review, fix, and health agent. You are responsible for PR #{number} ({title}).
 Branch: {branch}
 Current HEAD: {sha}
 Review reason: {reason}
+Has merge conflict: {has_conflict}
+Failing CI checks: {failing_checks}
 
-Your job has four phases: READ, REVIEW, COMMENT, FIX.
-Complete all four before exiting.
+Your job has six phases: READ, MERGE-FIX, CI-FIX, REVIEW, COMMENT, FIX.
+Complete all six before exiting.
+
+**IMPORTANT:** Use the LSP tool (rust-analyzer) throughout this process. Before and after every
+code fix, use `LSP hover`, `LSP goToDefinition`, and `LSP documentSymbol` to verify types,
+signatures, and symbol existence. Never guess at type signatures — ask the LSP.
 
 ---
 
@@ -136,6 +167,142 @@ Identify:
 - Issues already raised and FIXED (comment exists, fix appears in subsequent commits)
 - Issues already raised but NOT YET FIXED (comment exists, no fix in code)
 - Issues that are NEW (not yet commented on at all)
+
+---
+
+## PHASE M — Fix merge conflicts
+
+Check if the branch has conflicts with main:
+```bash
+git fetch origin main
+git merge-base HEAD origin/main
+git diff HEAD...origin/main --name-only
+```
+
+If the branch is behind main or has conflicts, rebase onto main:
+```bash
+git rebase origin/main
+```
+
+**If the rebase hits conflicts, resolve them file by file using these rules:**
+
+##### Cargo.toml conflicts (workspace members)
+The `members` array in the root `Cargo.toml` is the most common conflict.
+Both sides added different crates — the correct resolution is ALWAYS to include
+ALL entries from both sides, in alphabetical order within each logical group.
+
+When you see:
+```
+<<<<<<< HEAD
+    "canon-inbox-yugabyte",
+=======
+    "canon-snapshot-store-yugabyte",
+>>>>>>> origin/main
+```
+
+Resolve to include both:
+```toml
+    "canon-inbox-yugabyte",
+    "canon-snapshot-store-yugabyte",
+```
+
+##### Cargo.lock conflicts
+Never manually resolve Cargo.lock conflicts. After resolving Cargo.toml:
+```bash
+rm Cargo.lock
+cargo generate-lockfile 2>&1 | tail -5
+```
+
+##### ci.yml conflicts
+The canonical ci.yml includes the `libcurl4-openssl-dev` system dependency install.
+If one side has it and the other doesn't, keep the version that has it.
+
+##### canon-core/src/types.rs conflicts
+If both sides add `Version::from_u64`, keep exactly one copy:
+```rust
+pub fn from_u64(v: u64) -> Self {{ Self(v) }}
+```
+Remove the duplicate, keep one.
+
+##### README.md / CLAUDE.md conflicts
+These are documentation files. Read both sides, merge the content manually —
+keep all new sections from both sides. Never drop content added by either side.
+
+##### After resolving each conflict file:
+```bash
+git add <resolved-file>
+```
+
+Continue the rebase:
+```bash
+git rebase --continue
+```
+
+If the rebase cannot be completed cleanly, abort and use merge instead:
+```bash
+git rebase --abort
+git merge origin/main -m "merge: sync with main for PR #{number}"
+# Then resolve conflicts as above
+```
+
+If no conflicts exist and the branch is up to date, skip this phase.
+
+---
+
+## PHASE I — Fix CI failures
+
+After resolving any merge conflicts, verify the branch compiles and passes CI locally.
+Run these in order (`cargo check` before `cargo clippy` before `cargo test` — earlier failures mask later ones):
+
+```bash
+cargo check --workspace 2>&1 | tail -20
+```
+
+If `cargo check` fails, diagnose and fix. Common Canon compile errors:
+- `Version::from_u64` called but not defined — add to `canon-core/src/types.rs`:
+  ```rust
+  pub fn from_u64(v: u64) -> Self {{ Self(v) }}
+  ```
+- Missing trait impl — check the trait crate and implement correctly
+- Wrong error type — check the `From<>` impl chain
+- `debug_assert!` on a type that requires `Result` — convert to `?` propagation
+
+**Use the LSP to diagnose:** Before editing, use `LSP hover` on the problematic symbol
+to see what the compiler thinks its type is. Use `LSP goToDefinition` to find where
+traits and methods are actually defined.
+
+After each fix: `cargo check -p <crate>` to verify before moving on.
+
+Once `cargo check` is clean:
+```bash
+cargo clippy --workspace -- -D warnings 2>&1 | tail -20
+```
+
+Common Canon clippy issues:
+- Unused import — remove it
+- `unwrap()` in library code — convert to `?` or `.map_err()`
+- Redundant clone — remove it
+- `dead_code` on test helpers — delete the helper or add `#[cfg(test)]`
+
+After fixes: `cargo clippy --workspace -- -D warnings 2>&1 | grep "^error"`
+
+Once clippy is clean:
+```bash
+cargo test --workspace 2>&1 | tail -20
+```
+
+If tests fail, read the test, understand why it fails, fix either the implementation or
+the test. **Never delete a test to make CI pass.**
+
+If CI failures are caused by missing system dependencies (linker errors for `libssl`,
+`libcurl`, `libsasl`), check `.github/workflows/ci.yml` and add the install step if missing.
+
+**Use the LSP for validation:** Run `LSP documentSymbol` on every file you changed to
+verify the structure is correct. Use `LSP hover` on any symbol you're unsure about.
+
+Iterate until all three (`cargo check`, `cargo clippy`, `cargo test`) pass cleanly.
+
+If no CI failures exist, skip this phase.
 
 ---
 
@@ -265,18 +432,36 @@ cargo check -p <affected-crate> 2>&1 | head -30
 
 Fix any errors before continuing.
 
-Once all fixes are applied and `cargo check` is clean:
+Once all fixes are applied, run the full verification suite:
+
+```bash
+# Full workspace check
+cargo check --workspace 2>&1 | tail -5
+
+# Clippy clean
+cargo clippy --workspace -- -D warnings 2>&1 | grep "^error" | wc -l
+# Must be 0
+
+# Tests pass
+cargo test --workspace 2>&1 | tail -10
+```
+
+If anything still fails, iterate until clean.
+
+Once everything passes:
 
 ```bash
 git add -A
-git commit -m "fix(<crate>): address review comments
+git commit -m "fix(<crate>): address review comments, resolve conflicts and CI failures
 
-- <bullet per fix>
+- <bullet per review fix>
+- <bullet for conflicts resolved, if any>
+- <bullet for CI failures fixed, if any>
 - ...
 
 Fixes raised by /review-prs bot."
 
-git push origin {branch}
+git push --force-with-lease origin {branch}
 ```
 
 Then post a follow-up comment linking the fix commit:
@@ -289,6 +474,8 @@ review-prs-sha: $FIX_SHA
 ## Fix commit
 
 Applied fixes for all issues (🔴, 🟡, and 🟢) from the review above.
+Resolved merge conflicts: yes/no
+Fixed CI failures: yes/no
 Commit: \`$FIX_SHA\`
 
 Changes:
@@ -300,12 +487,21 @@ $(git show --stat HEAD | tail -n +2)"
 ## Rules for this agent
 
 - **CLAUDE.md is truth.** All architectural judgements defer to it.
+- **Use the LSP** — always verify types, definitions, and references via rust-analyzer before
+  and after making code changes. Never guess at method signatures or trait bounds.
+- **`cargo check` before `cargo clippy` before `cargo test`** — earlier failures mask later ones.
 - **Do not re-raise already-commented issues** — check existing comments first, always.
 - **Re-reviews are incremental.** On a re-review, only comment on issues introduced since the last reviewed SHA, or issues that were raised and are confirmed still present in the current code.
 - **One review API call per PR** — batch all inline comments into a single `gh api` call.
 - **Fix order matters** — `canon-core` changes before impl crate changes.
 - **No `TODO` in fixes** — if you can't fully fix something, explain in the comment why and what the author needs to do.
-- **`cargo check` must pass** after your fix commit.
+- **`cargo check`, `cargo clippy`, and `cargo test` must all pass** after your fix commit.
+- **`--force-with-lease` only** — never `--force`. If the push is rejected because the remote
+  was updated by someone else since the agent started, abort and report rather than overwriting.
+- **Never delete tests** to make CI pass — fix the implementation.
+- **Never drop content** from either side of a documentation conflict (CLAUDE.md, README.md).
+- **Rebase over merge** where possible — keeps the history linear. Fall back to merge
+  only if rebase produces unresolvable conflicts.
 - **Do not touch files outside the PR's changed set** unless a canon-core fix is strictly required and the PR description says it was intended.
 """
 
@@ -372,8 +568,11 @@ EOF
 
 When `/review-prs` is run again on a PR that has already been reviewed:
 
-- **Same HEAD SHA:** Agent is skipped entirely — "no new commits".
+- **Same HEAD SHA + healthy (no conflicts, no CI failures):** Agent is skipped entirely — "no new commits, healthy".
+- **Same HEAD SHA but has conflicts or CI failures:** Agent runs to fix conflicts/CI even though code hasn't changed.
 - **New HEAD SHA:** Agent runs but reads existing comments first. It will:
+  - Fix any merge conflicts with main
+  - Fix any CI failures
   - Skip any issue that already has a comment (whether fixed or not)
   - Only raise issues that are genuinely new in the changed code
   - Note in its summary how many previously-raised issues are still open vs. resolved
@@ -381,3 +580,44 @@ When `/review-prs` is run again on a PR that has already been reviewed:
 
 This means: **comments accumulate on the PR over time but are never duplicated.**
 Each review pass is scoped to what's new since the last reviewed SHA.
+
+---
+
+## Conflict resolution reference
+
+These are the specific conflict patterns in this Canon workspace:
+
+### Root `Cargo.toml` — workspace members
+Each PR adds one crate to the `members` array. When PRs diverge from the same base,
+the members list conflicts. Resolution: **include all entries, alphabetically sorted
+within each group** (core -> trait crates -> impl crates -> test -> demo).
+
+Canonical member order for impl crates:
+```toml
+"canon-adaptor-kafka",
+"canon-command-store-yugabyte",
+"canon-event-store-cassandra",
+"canon-inbox-yugabyte",
+"canon-inbound-queue-kafka",
+"canon-outbound-queue-kafka",
+"canon-projection-store-yugabyte",
+"canon-publisher-kafka",
+"canon-queue-rabbitmq",
+"canon-snapshot-store-yugabyte",
+```
+
+### `.github/workflows/ci.yml` — system dependencies
+Kafka PRs require `libcurl4-openssl-dev`. The canonical ci.yml always includes it.
+Never have two versions of ci.yml on different branches — the version with
+`libcurl4-openssl-dev` is always correct.
+
+### `canon-core/src/types.rs` — `Version::from_u64`
+Multiple PRs may add this method. The correct resolution is exactly one copy
+in the `impl Version` block, immediately after `as_u64`.
+
+### `Cargo.lock`
+Never manually resolve. Delete and regenerate after fixing `Cargo.toml`.
+
+### `README.md` / `CLAUDE.md`
+Documentation files. Read both sides, merge the content manually —
+keep all new sections from both sides. Never drop content added by either side.


### PR DESCRIPTION
## Summary

- Merges the merge-conflict resolution and CI failure fixing functionality from `/fix-prs` into `/review-prs`, so a single command handles everything: conflict resolution, CI fixes, code review, and fix commits.
- Adds two new phases to each per-PR agent: **PHASE M** (rebase onto main, resolve conflicts) and **PHASE I** (cargo check/clippy/test, fix failures) that run before the existing review phases.
- Adds the conflict resolution reference section (Cargo.toml members, Cargo.lock, ci.yml, canon-core/types.rs, README/CLAUDE.md patterns) at the bottom of the file.
- Updates Phase 0 discovery to also fetch `mergeable`, `mergeStateStatus`, and `statusCheckRollup` from GitHub, reporting conflict/CI status alongside review state.
- Updates agent rules to include LSP usage, build order (`check` before `clippy` before `test`), `--force-with-lease` only, and never deleting tests.
- Re-review now also triggers for PRs with same HEAD SHA but merge conflicts or CI failures.

## Test plan

- [ ] Verify `/review-prs` discovers PRs with conflicts and CI failures
- [ ] Verify PHASE M correctly rebases branches onto main
- [ ] Verify PHASE I runs cargo check/clippy/test and fixes failures
- [ ] Verify parallel agent architecture is preserved (no sequential merge-then-next flow)
- [ ] Verify fix commit message includes conflict/CI resolution status
- [ ] Verify previously-reviewed PRs with new conflicts/CI failures are re-processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)