### PR TITLE
fix(gateway): replace {id} with :id in axum route paths

### DIFF
--- a/canon-demo/gateway/src/routes/admin.rs
+++ b/canon-demo/gateway/src/routes/admin.rs
@@ -13,8 +13,8 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/admin/oversight/windows", get(list_oversight_windows))
         .route("/admin/deadletters", get(list_dead_letters))
-        .route("/admin/deadletters/{id}/requeue", post(requeue_dead_letter))
-        .route("/admin/deadletters/{id}", delete(discard_dead_letter))
+        .route("/admin/deadletters/:id/requeue", post(requeue_dead_letter))
+        .route("/admin/deadletters/:id", delete(discard_dead_letter))
 }
 
 // ── Row types for sqlx::query_as ────────────────────────────────────────────

--- a/canon-demo/gateway/src/routes/cargo.rs
+++ b/canon-demo/gateway/src/routes/cargo.rs
@@ -19,9 +19,9 @@ use crate::types::{
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/cargo/manifests", post(create_manifest))
-        .route("/cargo/manifests/{id}/load", post(load_cargo))
-        .route("/cargo/manifests/{id}/unload", post(begin_unloading))
-        .route("/cargo/manifests/{id}", get(manifest_history))
+        .route("/cargo/manifests/:id/load", post(load_cargo))
+        .route("/cargo/manifests/:id/unload", post(begin_unloading))
+        .route("/cargo/manifests/:id", get(manifest_history))
 }
 
 /// POST /cargo/manifests — CreateManifest command

--- a/canon-demo/gateway/src/routes/fleet.rs
+++ b/canon-demo/gateway/src/routes/fleet.rs
@@ -21,11 +21,11 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/ships", get(list_ships))
         .route("/fleet/ships", post(register_ship))
-        .route("/fleet/ships/{id}/route", post(assign_route))
-        .route("/fleet/ships/{id}/depart", post(depart_for_station))
-        .route("/fleet/ships/{id}/resupply", post(schedule_resupply))
-        .route("/fleet/ships/{id}/decommission", post(decommission_ship))
-        .route("/ships/{id}/history", get(ship_history))
+        .route("/fleet/ships/:id/route", post(assign_route))
+        .route("/fleet/ships/:id/depart", post(depart_for_station))
+        .route("/fleet/ships/:id/resupply", post(schedule_resupply))
+        .route("/fleet/ships/:id/decommission", post(decommission_ship))
+        .route("/ships/:id/history", get(ship_history))
 }
 
 /// POST /fleet/ships — RegisterShip command

--- a/canon-demo/gateway/src/routes/navigation.rs
+++ b/canon-demo/gateway/src/routes/navigation.rs
@@ -16,7 +16,7 @@ use crate::types::{CommandAcceptedResponse, EventHistoryEntry, PlanRouteRequest}
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/navigation/routes", post(plan_route))
-        .route("/navigation/routes/{id}", get(route_history))
+        .route("/navigation/routes/:id", get(route_history))
 }
 
 /// POST /navigation/routes — PlanRoute command

--- a/canon-demo/gateway/src/routes/station.rs
+++ b/canon-demo/gateway/src/routes/station.rs
@@ -16,10 +16,10 @@ use crate::types::{
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/stations", get(list_stations))
-        .route("/stations/{id}/register", post(register_station))
-        .route("/stations/{id}/dock", post(record_docking))
-        .route("/stations/{id}/cargo", post(record_cargo_received))
-        .route("/stations/{id}/inventory", get(station_inventory))
+        .route("/stations/:id/register", post(register_station))
+        .route("/stations/:id/dock", post(record_docking))
+        .route("/stations/:id/cargo", post(record_cargo_received))
+        .route("/stations/:id/inventory", get(station_inventory))
 }
 
 /// POST /stations/:id/register — RegisterStation command


### PR DESCRIPTION
## Summary

Fixes all gateway routes with path parameters returning 404. axum 0.7 uses `:id` colon syntax, not `{id}` brace syntax. The brace syntax compiled without error but was treated as a literal path segment, so every parameterised endpoint returned 404 at runtime.

Closes #244.

## Affected routes

- **fleet.rs**: 5 routes (route, depart, resupply, decommission, history)
- **station.rs**: 4 routes (register, dock, cargo, inventory)
- **cargo.rs**: 3 routes (load, unload, history)
- **navigation.rs**: 1 route (history)
- **admin.rs**: 2 routes (requeue, discard)

## Test plan

- [x] `cargo check -p gateway` passes
- [x] `cargo clippy -p gateway -- -D warnings` passes (zero warnings)
- [x] `cargo test -p gateway` passes
- [ ] Manual test: `curl -X POST http://localhost:8080/stations/<uuid>/register` returns 200 (not 404)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)