### PR TITLE
fix(docker): shared builder image + trixie-slim runtime

### DIFF
--- a/canon-demo/Dockerfile.builder
+++ b/canon-demo/Dockerfile.builder
@@ -1,0 +1,19 @@
+FROM rust:latest AS builder
+WORKDIR /usr/src/canon
+
+# Install system dependencies for rdkafka (cmake-build) and OpenSSL
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake pkg-config libssl-dev libsasl2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy entire workspace
+COPY . .
+
+# Build all 6 demo services in one pass
+RUN cargo build --release \
+    -p gateway \
+    -p fleet-service \
+    -p cargo-service \
+    -p navigation-service \
+    -p station-service \
+    -p supply-service

--- a/canon-demo/cargo-service/Dockerfile
+++ b/canon-demo/cargo-service/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p cargo-service
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/cargo-service /usr/local/bin/cargo-service
 CMD ["cargo-service"]

--- a/canon-demo/docker-compose.yml
+++ b/canon-demo/docker-compose.yml
@@ -1,3 +1,6 @@
+# Build all service images:
+#   docker build -f canon-demo/Dockerfile.builder -t canon-builder .
+#   cd canon-demo && docker compose up -d --build
 services:
   yugabytedb:
     image: yugabytedb/yugabyte:2.23.1.0-b220

--- a/canon-demo/fleet-service/Dockerfile
+++ b/canon-demo/fleet-service/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p fleet-service
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/fleet-service /usr/local/bin/fleet-service
 CMD ["fleet-service"]

--- a/canon-demo/gateway/Dockerfile
+++ b/canon-demo/gateway/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p gateway
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/gateway /usr/local/bin/gateway
 CMD ["gateway"]

--- a/canon-demo/navigation-service/Dockerfile
+++ b/canon-demo/navigation-service/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p navigation-service
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/navigation-service /usr/local/bin/navigation-service
 CMD ["navigation-service"]

--- a/canon-demo/station-service/Dockerfile
+++ b/canon-demo/station-service/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p station-service
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/station-service /usr/local/bin/station-service
 CMD ["station-service"]

--- a/canon-demo/supply-service/Dockerfile
+++ b/canon-demo/supply-service/Dockerfile
@@ -1,44 +1,5 @@
-# Stage 1: Build
-FROM rust:1.83-bookworm AS builder
-WORKDIR /usr/src/canon
-
-# Install system dependencies for rdkafka (cmake-build) and OpenSSL
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake pkg-config libssl-dev libsasl2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy entire workspace — needed for inter-crate dependencies
-COPY Cargo.toml Cargo.lock ./
-COPY canon-core/ canon-core/
-COPY canon-event-store/ canon-event-store/
-COPY canon-event-store-cassandra/ canon-event-store-cassandra/
-COPY canon-command-store/ canon-command-store/
-COPY canon-command-store-yugabyte/ canon-command-store-yugabyte/
-COPY canon-snapshot-store/ canon-snapshot-store/
-COPY canon-snapshot-store-yugabyte/ canon-snapshot-store-yugabyte/
-COPY canon-inbox/ canon-inbox/
-COPY canon-inbox-yugabyte/ canon-inbox-yugabyte/
-COPY canon-inbound-queue/ canon-inbound-queue/
-COPY canon-inbound-queue-kafka/ canon-inbound-queue-kafka/
-COPY canon-outbound-queue/ canon-outbound-queue/
-COPY canon-outbound-queue-kafka/ canon-outbound-queue-kafka/
-COPY canon-projection-store/ canon-projection-store/
-COPY canon-projection-store-yugabyte/ canon-projection-store-yugabyte/
-COPY canon-publisher/ canon-publisher/
-COPY canon-publisher-kafka/ canon-publisher-kafka/
-COPY canon-adaptor/ canon-adaptor/
-COPY canon-adaptor-kafka/ canon-adaptor-kafka/
-COPY canon-deadletter/ canon-deadletter/
-COPY canon-deadletter-yugabyte/ canon-deadletter-yugabyte/
-COPY canon-test/ canon-test/
-COPY canon-demo/ canon-demo/
-
-RUN cargo build --release -p supply-service
-
-# Stage 2: Runtime
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 libsasl2-2 \
-    && rm -rf /var/lib/apt/lists/*
+FROM canon-builder:latest AS builder
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl3 libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/canon/target/release/supply-service /usr/local/bin/supply-service
 CMD ["supply-service"]


### PR DESCRIPTION
## Summary

Fixes Docker builds by using a single shared builder image that compiles all 6 services once, then thin runtime images copy their binary from it. Runtime uses debian:trixie-slim (GLIBC 2.38+).

Part of #252.

## Approach

**Builder** (canon-demo/Dockerfile.builder):
- `rust:latest` with cmake/ssl/sasl dev deps
- `cargo build --release -p gateway -p fleet-service ...`
- One compilation, all 6 binaries

**Runtime** (each service Dockerfile):
- `FROM canon-builder:latest AS builder`
- `FROM debian:trixie-slim` (GLIBC 2.38+)
- `COPY --from=builder` the binary
- 5 lines per Dockerfile

## Why not the previous approaches

- **zigbuild**: rdkafka-sys cmake build fails with zig linker
- **Multi-stage per service**: OOMs building 6 full workspaces in parallel
- **bookworm-slim runtime**: GLIBC 2.36, binaries need 2.38

## Test plan

- [ ] `docker build -f canon-demo/Dockerfile.builder -t canon-builder .` completes successfully
- [ ] `cd canon-demo && docker compose up -d --build` starts all services
- [ ] All 6 services start and connect to infrastructure (Kafka, YugabyteDB, Cassandra)
- [ ] Pipeline works end-to-end: commands flow through outbox to Kafka to event store

🤖 Generated with [Claude Code](https://claude.ai/claude-code)