### PR TITLE
feat(frontend): copper theme restyle

### DIFF
--- a/canon-demo/frontend/index.html
+++ b/canon-demo/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Canon — Fleet Ops Demo</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
     <link data-trunk rel="css" href="style/main.css">
     <link data-trunk rel="rust" data-wasm-opt="z">
     <link data-trunk rel="copy-file" href="config.js" />

--- a/canon-demo/frontend/reference/mockup.html
+++ b/canon-demo/frontend/reference/mockup.html
@@ -4,36 +4,38 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Canon — Fleet Ops Demo</title>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
 <style>
 :root {
-  --bg:#070f1c; --panel:#0d1e33; --raised:#112540;
-  --border:rgba(0,160,230,.18); --borderhi:rgba(0,160,230,.45);
-  --cyan:#00b4ff; --cyandim:rgba(0,180,255,.5);
+  --bg:#0f0d0b; --panel:#1a1614; --raised:#231e1a;
+  --border:rgba(212,135,94,.18); --borderhi:rgba(212,135,94,.45);
+  --accent:#d4875e; --accentdim:rgba(212,135,94,.5);
   --green:#00e58a; --greendim:rgba(0,229,138,.55);
   --amber:#f5a623; --amberdim:rgba(245,166,35,.55);
   --red:#ff4069; --reddim:rgba(255,64,105,.55);
   --purple:#a78bfa;
-  --txt:#9db8d2; --txthi:#daeaf8; --txtlo:#4e6a82;
-  --grid:rgba(0,160,230,.032);
-  --logbg:rgba(0,160,230,.05); --loglit:rgba(0,160,230,.09); --logorig:rgba(0,160,230,.15);
-  --divclr:rgba(0,160,230,.07);
-  --shadow:rgba(0,0,0,.45);
+  --txt:#a89888; --txthi:#e0d2c4; --txtlo:#6b5d50;
+  --grid:rgba(212,135,94,.04);
+  --logbg:rgba(212,135,94,.05); --loglit:rgba(212,135,94,.09); --logorig:rgba(212,135,94,.15);
+  --divclr:rgba(212,135,94,.07);
+  --shadow:rgba(0,0,0,.55);
   --mono:'JetBrains Mono',monospace; --sans:'Inter',sans-serif; --body:'Inter',sans-serif;
+  --copper:#d4875e;
 }
 body.light {
-  --bg:#eef3f9; --panel:#fff; --raised:#f4f8fd;
-  --border:rgba(0,120,180,.15); --borderhi:rgba(0,120,180,.4);
-  --cyan:#0086cc; --cyandim:rgba(0,134,204,.55);
+  --bg:#f5f0eb; --panel:#fff; --raised:#faf6f2;
+  --border:rgba(176,102,74,.15); --borderhi:rgba(176,102,74,.4);
+  --accent:#b0664a; --accentdim:rgba(176,102,74,.55);
   --green:#00a86b; --greendim:rgba(0,168,107,.6);
   --amber:#d4820a; --amberdim:rgba(212,130,10,.6);
   --red:#d42e55; --reddim:rgba(212,46,85,.6);
   --purple:#7c3aed;
-  --txt:#3d5a7a; --txthi:#0f2a45; --txtlo:#7a9ab8;
-  --grid:rgba(0,120,180,.06);
-  --logbg:rgba(0,120,180,.04); --loglit:rgba(0,120,180,.08); --logorig:rgba(0,120,180,.14);
-  --divclr:rgba(0,120,180,.1);
+  --txt:#5a4a3e; --txthi:#2a1e14; --txtlo:#9a8878;
+  --grid:rgba(176,102,74,.06);
+  --logbg:rgba(176,102,74,.04); --loglit:rgba(176,102,74,.08); --logorig:rgba(176,102,74,.14);
+  --divclr:rgba(176,102,74,.1);
   --shadow:rgba(0,0,0,.12);
+  --copper:#b0664a;
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--txt);font-family:var(--sans);height:100vh;overflow:hidden;display:flex;flex-direction:column;transition:background .3s,color .3s;}
@@ -42,9 +44,8 @@ body.light::before{opacity:0;}
 
 /* HEADER */
 header{position:relative;z-index:20;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:56px;background:var(--panel);border-bottom:1px solid var(--border);flex-shrink:0;transition:background .3s,border-color .3s;}
-.logo{font-family:var(--sans);font-weight:800;font-size:20px;color:var(--txthi);user-select:none;transition:color .3s;letter-spacing:.02em;}
-.logo .a{color:var(--cyan);}
-.logo-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-left:10px;font-weight:400;}
+.logo{font-family:'Josefin Sans',sans-serif;font-weight:300;font-size:22px;color:var(--copper);user-select:none;transition:color .3s;letter-spacing:.32em;text-transform:uppercase;}
+.logo-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-left:12px;font-weight:400;}
 .hdr-r{display:flex;align-items:center;gap:18px;}
 .infra{display:flex;gap:14px;}
 .ii{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:12px;color:var(--txtlo);transition:color .3s;}
@@ -54,14 +55,14 @@ header{position:relative;z-index:20;display:flex;align-items:center;justify-cont
 .theme-btn{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--txtlo);cursor:pointer;padding-left:16px;border-left:1px solid var(--border);user-select:none;transition:color .2s,border-color .3s;}
 .theme-btn:hover{color:var(--txt);}
 .trk{width:36px;height:20px;border-radius:10px;background:var(--border);border:1px solid var(--borderhi);position:relative;transition:all .3s;flex-shrink:0;}
-body:not(.light) .trk{background:var(--cyan);border-color:var(--cyan);}
+body:not(.light) .trk{background:var(--accent);border-color:var(--accent);}
 .thmb{width:14px;height:14px;border-radius:50%;background:#fff;position:absolute;top:2px;left:2px;transition:transform .3s,background .3s;box-shadow:0 1px 3px rgba(0,0,0,.2);}
 body:not(.light) .thmb{transform:translateX(16px);}
 
 /* NAV TABS — inline in header */
 .tnav-tab{padding:0 4px;height:56px;display:inline-flex;align-items:center;font-family:var(--sans);font-size:14px;font-weight:600;color:var(--txtlo);cursor:pointer;border-bottom:2px solid transparent;transition:color .15s,border-color .15s;margin:0 8px;}
 .tnav-tab:hover{color:var(--txt);}
-.tnav-tab.active{color:var(--cyan);border-bottom-color:var(--cyan);}
+.tnav-tab.active{color:var(--accent);border-bottom-color:var(--accent);}
 
 /* PAGES */
 .page{display:none;flex:1;min-height:0;flex-direction:column;}
@@ -77,7 +78,7 @@ body:not(.light) .thmb{transform:translateX(16px);}
 /* STATION CARDS */
 .stn-card{flex:1;padding:18px 22px;border-right:1px solid var(--border);background:var(--panel);transition:background .2s,border-color .2s;position:relative;}
 .stn-card:last-child{border-right:none;}
-.stn-card.active-stn{background:var(--raised);border-top:3px solid var(--cyan);}
+.stn-card.active-stn{background:var(--raised);border-top:3px solid var(--accent);}
 .stn-card-name{font-family:var(--sans);font-size:15px;font-weight:700;color:var(--txthi);margin-bottom:2px;}
 .stn-card-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-bottom:12px;}
 .stn-card-bar{height:10px;background:var(--border);border-radius:5px;overflow:hidden;margin-bottom:8px;}
@@ -95,9 +96,9 @@ body:not(.light) .thmb{transform:translateX(16px);}
 ::-webkit-scrollbar{width:4px;}::-webkit-scrollbar-thumb{background:var(--borderhi);border-radius:2px;}
 .log-item{padding:7px 20px;border-left:3px solid transparent;cursor:pointer;transition:background .12s;display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--divclr);}
 .log-item:hover{background:var(--logbg);}
-.log-item.lit{background:var(--loglit);border-left-color:var(--cyan);}
+.log-item.lit{background:var(--loglit);border-left-color:var(--accent);}
 .log-item.fresh{animation:flash .5s ease-out;}
-@keyframes flash{0%{background:rgba(0,120,180,.18)}100%{background:transparent}}
+@keyframes flash{0%{background:rgba(212,135,94,.18)}100%{background:transparent}}
 .log-ts{font-family:var(--mono);font-size:11px;color:var(--txtlo);white-space:nowrap;flex-shrink:0;}
 .log-row{display:flex;align-items:center;gap:7px;flex:1;min-width:0;}
 .log-name{font-family:var(--sans);font-size:13px;font-weight:600;color:var(--txthi);white-space:nowrap;}
@@ -105,42 +106,42 @@ body:not(.light) .thmb{transform:translateX(16px);}
 .log-corr{display:none;}
 .log-div{display:none;}
 .svc{font-family:var(--sans);font-size:10px;padding:2px 7px;border-radius:3px;flex-shrink:0;font-weight:600;}
-.sf{background:rgba(0,120,180,.12);color:#005fa8;}
+.sf{background:rgba(176,102,74,.12);color:#8b5a3a;}
 .sc{background:rgba(124,58,237,.12);color:#5b21b6;}
 .sn{background:rgba(0,168,107,.12);color:#00694a;}
 .ss{background:rgba(212,130,10,.12);color:#92570a;}
 .su{background:rgba(212,46,85,.12);color:#991b3d;}
-body:not(.light) .sf{background:rgba(0,180,255,.12);color:var(--cyan);}
+body:not(.light) .sf{background:rgba(212,135,94,.12);color:var(--accent);}
 body:not(.light) .sc{background:rgba(167,139,250,.14);color:var(--purple);}
 body:not(.light) .sn{background:rgba(0,229,138,.11);color:var(--green);}
 body:not(.light) .ss{background:rgba(245,166,35,.12);color:var(--amber);}
 body:not(.light) .su{background:rgba(255,64,105,.11);color:var(--red);}
 .sb-footer{padding:8px 20px;border-top:1px solid var(--border);font-family:var(--sans);font-size:12px;color:var(--txtlo);background:var(--panel);}
-.sb-footer a{color:var(--cyan);cursor:pointer;text-decoration:underline;text-underline-offset:2px;}
+.sb-footer a{color:var(--accent);cursor:pointer;text-decoration:underline;text-underline-offset:2px;}
 
 /* POPUP */
 .cmd-popup{display:none;position:absolute;z-index:50;background:var(--panel);border:1px solid var(--borderhi);padding:16px 18px;min-width:240px;box-shadow:0 8px 32px var(--shadow);border-radius:4px;transition:background .3s,border-color .3s;}
-.cmd-popup::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--cyan),transparent);border-radius:4px 4px 0 0;}
+.cmd-popup::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--accent),transparent);border-radius:4px 4px 0 0;}
 .popup-ship{font-family:var(--sans);font-size:16px;font-weight:700;color:var(--txthi);margin-bottom:3px;}
 .popup-stat{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:12px;}
-.popup-hint{font-family:var(--mono);font-size:11px;color:var(--cyandim);margin-bottom:8px;}
+.popup-hint{font-family:var(--mono);font-size:11px;color:var(--accentdim);margin-bottom:8px;}
 .dest-list{display:flex;flex-direction:column;gap:5px;}
 .dest-btn{display:flex;align-items:center;justify-content:space-between;padding:9px 12px;border:1px solid var(--border);border-radius:3px;background:transparent;cursor:pointer;font-family:var(--mono);font-size:11px;color:var(--txt);text-align:left;transition:all .15s;}
-.dest-btn:hover{background:rgba(0,120,180,.06);border-color:var(--borderhi);color:var(--txthi);}
-.dest-btn .arr{color:var(--cyandim);font-size:14px;}
+.dest-btn:hover{background:rgba(212,135,94,.06);border-color:var(--borderhi);color:var(--txthi);}
+.dest-btn .arr{color:var(--accentdim);font-size:14px;}
 .dest-btn.cur{opacity:.4;cursor:not-allowed;}
 .dest-btn.cur:hover{background:transparent;border-color:var(--border);color:var(--txt);}
 .popup-info{margin-top:12px;padding-top:12px;border-top:1px solid var(--border);}
 .pi-row{display:flex;justify-content:space-between;font-family:var(--mono);font-size:12px;padding:3px 0;}
 .pi-k{color:var(--txtlo);}
 .pi-v{color:var(--txthi);}
-.pi-v.c{color:var(--cyan);}
+.pi-v.c{color:var(--accent);}
 .pi-v.a{color:var(--amber);}
 .pi-v.g{color:var(--green);}
 .snap-wrap{margin-top:8px;}
 .snap-lbl{display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:5px;}
 .snap-track{height:4px;background:var(--border);border-radius:2px;position:relative;overflow:visible;}
-.snap-fill{height:100%;background:var(--cyan);border-radius:2px;transition:width .4s;}
+.snap-fill{height:100%;background:var(--accent);border-radius:2px;transition:width .4s;}
 .snap-mark{position:absolute;left:0;top:-4px;width:1px;height:12px;background:var(--amber);opacity:.7;}
 
 /* OVERSIGHT STRIP */
@@ -158,6 +159,23 @@ body:not(.light) .os-strip{background:rgba(7,15,28,.92);}
 .os-req .lb{color:var(--txtlo);}
 .os-req.met .lb{color:var(--txthi);}
 
+/* EVENT LOG PANEL (inline, pushes map) */
+.live-content{display:flex;flex:1;min-height:0;overflow:hidden;}
+.live-main{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0;transition:flex .3s cubic-bezier(.4,0,.2,1);}
+.log-panel{width:0;overflow:hidden;background:var(--panel);border-left:1px solid transparent;display:flex;flex-direction:column;flex-shrink:0;transition:width .3s cubic-bezier(.4,0,.2,1),border-color .3s;}
+.log-panel.open{width:380px;border-left-color:var(--border);}
+.log-panel-hdr{display:flex;align-items:center;justify-content:space-between;padding:14px 20px;border-bottom:1px solid var(--border);flex-shrink:0;min-width:380px;}
+.log-panel-hdr .bar-lbl{font-size:14px;font-weight:700;}
+.log-panel-close{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11px;color:var(--txtlo);cursor:pointer;padding:5px 10px;border:1px solid var(--border);border-radius:3px;transition:all .15s;background:transparent;}
+.log-panel-close:hover{border-color:var(--borderhi);color:var(--txt);}
+.log-panel .log-body{flex:1;max-height:none !important;overflow-y:auto;min-width:380px;}
+.log-panel .sb-footer{margin-top:auto;min-width:380px;}
+.log-toggle{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--txtlo);cursor:pointer;padding:5px 14px;border:1px solid var(--border);border-radius:3px;transition:all .15s;background:transparent;user-select:none;}
+.log-toggle:hover{border-color:var(--borderhi);color:var(--txt);}
+.log-toggle.active{border-color:var(--accent);color:var(--accent);}
+.log-toggle .dot{width:6px;height:6px;}
+.log-count{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;border-radius:9px;background:rgba(212,135,94,.15);color:var(--accent);font-family:var(--mono);font-size:10px;font-weight:600;padding:0 5px;}
+
 /* TOAST */
 .toast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:var(--raised);border:1px solid var(--borderhi);padding:10px 20px;font-family:var(--mono);font-size:12px;color:var(--txthi);z-index:300;white-space:nowrap;animation:tin .25s ease;pointer-events:none;border-radius:4px;}
 @keyframes tin{from{opacity:0;transform:translateX(-50%) translateY(8px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
@@ -170,20 +188,20 @@ body:not(.light) .os-strip{background:rgba(7,15,28,.92);}
 
 .sc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:18px;padding:28px 40px;}
 .sc-card{background:var(--panel);border:1px solid var(--border);padding:22px 24px;cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--cyan),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
+.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--accent),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
 .sc-card:hover{border-color:var(--borderhi);box-shadow:0 4px 20px var(--shadow);}
 .sc-card:hover::before{opacity:1;}
-.sc-card.active{border-color:var(--cyan);background:var(--raised);}
+.sc-card.active{border-color:var(--accent);background:var(--raised);}
 .sc-card.active::before{opacity:1;}
 .sc-num{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:8px;}
 .sc-name{font-family:var(--sans);font-size:18px;font-weight:700;color:var(--txthi);margin-bottom:6px;}
-.sc-ship{font-family:var(--mono);font-size:12px;color:var(--cyan);margin-bottom:10px;}
+.sc-ship{font-family:var(--mono);font-size:12px;color:var(--accent);margin-bottom:10px;}
 .sc-desc{font-family:var(--sans);font-size:13px;color:var(--txt);line-height:1.6;margin-bottom:12px;}
 .sc-tags{display:flex;flex-wrap:wrap;gap:6px;}
 .sc-tag{font-family:var(--mono);font-size:10px;padding:3px 9px;border-radius:3px;background:var(--raised);color:var(--txtlo);border:1px solid var(--border);}
 body.light .sc-tag{background:var(--bg);}
-.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--cyan);cursor:pointer;transition:all .2s;border-radius:3px;}
-.sc-launch:hover{background:rgba(0,120,180,.08);}
+.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--accent);cursor:pointer;transition:all .2s;border-radius:3px;}
+.sc-launch:hover{background:rgba(212,135,94,.08);}
 
 /* SCENARIO RUNNER */
 .sc-runner{display:none;position:fixed;inset:0;z-index:100;background:rgba(7,15,28,.97);flex-direction:column;overflow:hidden;}
@@ -203,11 +221,11 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .step{display:flex;align-items:center;gap:0;}
 .step-dot{width:28px;height:28px;border-radius:50%;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:11px;color:var(--txtlo);flex-shrink:0;transition:all .3s;}
 .step.done .step-dot{background:var(--green);border-color:var(--green);color:#fff;}
-.step.active .step-dot{background:var(--cyan);border-color:var(--cyan);color:#fff;box-shadow:0 0 10px var(--cyandim);}
+.step.active .step-dot{background:var(--accent);border-color:var(--accent);color:#fff;box-shadow:0 0 10px var(--accentdim);}
 .step-line{width:28px;height:1px;background:var(--border);flex-shrink:0;}
 .step.done .step-line{background:var(--green);}
 .step-lbl{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-left:8px;white-space:nowrap;}
-.step.active .step-lbl{color:var(--cyan);}
+.step.active .step-lbl{color:var(--accent);}
 .step.done  .step-lbl{color:var(--greendim);}
 .step-gap{width:16px;flex-shrink:0;}
 
@@ -216,9 +234,9 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .sc-narr-title{font-family:var(--sans);font-size:16px;font-weight:700;color:var(--txthi);margin-bottom:8px;}
 .sc-narr-body{font-family:var(--sans);font-size:14px;color:var(--txt);line-height:1.65;max-width:620px;}
 .sc-action-area{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:28px;gap:18px;}
-.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--cyan);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--cyan);}
-.sc-big-btn:hover{background:rgba(0,120,180,.08);box-shadow:0 0 20px rgba(0,120,180,.15);}
+.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--accent);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
+.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--accent);}
+.sc-big-btn:hover{background:rgba(212,135,94,.08);box-shadow:0 0 20px rgba(212,135,94,.15);}
 .sc-big-btn:disabled{opacity:.4;cursor:not-allowed;}
 .sc-sub-btn{font-family:var(--mono);font-size:12px;padding:9px 22px;border:1px solid var(--border);background:transparent;color:var(--txt);cursor:pointer;transition:all .2s;border-radius:3px;}
 .sc-sub-btn:hover{border-color:var(--borderhi);color:var(--txthi);}
@@ -239,10 +257,10 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 
 /* event counter (hydration viz) */
 .hydrate-viz{width:100%;max-width:400px;text-align:center;}
-.hv-counter{font-family:var(--mono);font-size:48px;color:var(--cyan);line-height:1;margin-bottom:8px;transition:color .3s;}
+.hv-counter{font-family:var(--mono);font-size:48px;color:var(--accent);line-height:1;margin-bottom:8px;transition:color .3s;}
 .hv-label{font-family:var(--mono);font-size:12px;color:var(--txtlo);margin-bottom:16px;}
 .hv-bar{height:5px;background:var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px;}
-.hv-fill{height:100%;background:var(--cyan);transition:width .05s linear;}
+.hv-fill{height:100%;background:var(--accent);transition:width .05s linear;}
 .hv-status{font-family:var(--mono);font-size:12px;color:var(--txtlo);}
 
 /* oversight scenario viz */
@@ -276,7 +294,7 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .cargo-val{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--txthi);}
 .cargo-btns{display:flex;gap:6px;}
 .cargo-btn{font-family:var(--mono);font-size:12px;padding:6px 14px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--txt);cursor:pointer;transition:all .15s;}
-.cargo-btn:hover:not(:disabled){border-color:var(--borderhi);background:rgba(0,120,180,.06);color:var(--txthi);}
+.cargo-btn:hover:not(:disabled){border-color:var(--borderhi);background:rgba(212,135,94,.06);color:var(--txthi);}
 .cargo-btn:disabled{opacity:.35;cursor:not-allowed;}
 .cargo-btn.load{border-color:var(--green);color:var(--green);}
 .cargo-btn.load:hover:not(:disabled){background:rgba(0,168,107,.08);}
@@ -292,7 +310,7 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 <header>
   <div style="display:flex;align-items:center;gap:0;">
     <div style="display:flex;align-items:baseline;margin-right:32px;">
-      <div class="logo">C<span class="a">A</span>NON</div>
+      <div class="logo">Canon</div>
       <div class="logo-sub">/ fleet ops demo</div>
     </div>
     <div class="tnav-tab active" onclick="showPage('live',this)">Live Fleet</div>
@@ -309,38 +327,50 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 
 <!-- ═══ LIVE PAGE ═══ -->
 <div class="page live-page active" id="page-live">
-  <div class="map-wrap">
-    <div class="map-bar">
-      <div class="bar-lbl">VSS Meridian</div>
-      <div id="destBar" style="display:flex;gap:8px;align-items:center;"></div>
-    </div>
-    <div class="map-canvas" id="mapCanvas">
-      <canvas id="mapCv" style="position:absolute;inset:0;width:100%;height:100%;"></canvas>
-      <div class="cmd-popup" id="popup">
-        <div class="popup-ship" id="popupName"></div>
-        <div class="popup-stat" id="popupStat"></div>
-        <div class="popup-hint">Select destination:</div>
-        <div class="dest-list" id="destList"></div>
-        <div class="popup-info" id="popupInfo"></div>
-      </div>
-      <div class="os-strip" id="osStrip" style="display:none;">
-        <div class="os-hdr">
-          <div class="os-title" id="osTitle"></div>
-          <div class="os-badge os-nr" id="osBadge">Not Ready</div>
+  <div class="live-content">
+    <div class="live-main">
+      <div class="map-wrap">
+        <div class="map-bar">
+          <div class="bar-lbl">VSS Meridian</div>
+          <button class="log-toggle" id="logToggleBtn" onclick="toggleLogDrawer()">
+            <div class="dot"></div>Event Log <span class="log-count" id="logCount">0</span>
+          </button>
         </div>
-        <div class="os-reqs" id="osReqs"></div>
+        <div class="map-canvas" id="mapCanvas">
+          <canvas id="mapCv" style="position:absolute;inset:0;width:100%;height:100%;"></canvas>
+          <div class="cmd-popup" id="popup">
+            <div class="popup-ship" id="popupName"></div>
+            <div class="popup-stat" id="popupStat"></div>
+            <div class="popup-hint">Select destination:</div>
+            <div class="dest-list" id="destList"></div>
+            <div class="popup-info" id="popupInfo"></div>
+          </div>
+          <div class="os-strip" id="osStrip" style="display:none;">
+            <div class="os-hdr">
+              <div class="os-title" id="osTitle"></div>
+              <div class="os-badge os-nr" id="osBadge">Not Ready</div>
+            </div>
+            <div class="os-reqs" id="osReqs"></div>
+          </div>
+        </div>
+        <!-- STATION CARDS -->
+        <div id="stationCards" style="display:flex;gap:0;border-top:1px solid var(--border);flex-shrink:0;"></div>
+        <!-- SHIP ACTION BAR -->
+        <div id="shipPanel" style="padding:12px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;display:flex;align-items:center;gap:16px;"></div>
       </div>
     </div>
-    <!-- STATION CARDS -->
-    <div id="stationCards" style="display:flex;gap:0;border-top:1px solid var(--border);flex-shrink:0;"></div>
-    <!-- SHIP ACTION BAR -->
-    <div id="shipPanel" style="padding:12px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;display:flex;align-items:center;gap:16px;"></div>
-    <!-- EVENT LOG STRIP -->
-    <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;">
-      <span class="bar-lbl">Event log</span>
-      <div class="live-badge"><div class="dot"></div>Live</div>
+    <!-- EVENT LOG PANEL (inline) -->
+    <div class="log-panel" id="logDrawer">
+      <div class="log-panel-hdr">
+        <div style="display:flex;align-items:center;gap:10px;">
+          <span class="bar-lbl">Event Log</span>
+          <div class="live-badge"><div class="dot"></div>Live</div>
+        </div>
+        <button class="log-panel-close" onclick="toggleLogDrawer()">✕ Close</button>
+      </div>
+      <div class="log-body" id="logBody"></div>
+      <div class="sb-footer">Events are append-only — <a onclick="hlRandom()">highlight random correlation</a></div>
     </div>
-    <div class="log-body" id="logBody" style="max-height:160px;"></div>
   </div>
 </div>
 
@@ -471,6 +501,19 @@ function showToast(msg){
   document.body.appendChild(el);setTimeout(()=>el.remove(),2800);
 }
 
+let logDrawerOpen=false;
+function toggleLogDrawer(){
+  logDrawerOpen=!logDrawerOpen;
+  document.getElementById('logDrawer').classList.toggle('open',logDrawerOpen);
+  document.getElementById('logToggleBtn').classList.toggle('active',logDrawerOpen);
+  // resize canvas after transition so map fills the new space
+  setTimeout(resizeCanvas,320);
+}
+function updateLogCount(){
+  const el=document.getElementById('logCount');
+  if(el)el.textContent=liveLog.length;
+}
+
 // ══════════════════════════════════════════════════════
 // GAME LOGIC
 // ══════════════════════════════════════════════════════
@@ -531,7 +574,7 @@ function renderGamePanel(){
     }
   } else if(ship.cargo>0){
     if(ship.cargoFor===curSt.id){
-      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--cyan);">${curSt.label}</strong></span>`+
+      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--accent);">${curSt.label}</strong></span>`+
         `<button class="cargo-btn unload" style="margin-left:auto;" onclick="unloadCargo()">Deliver supplies here</button>`;
     } else {
       const destSt=STATIONS.find(s=>s.id===ship.cargoFor);
@@ -540,7 +583,7 @@ function renderGamePanel(){
   } else {
     const suppliesFor=STATIONS.find(s=>s.suppliedBy===curSt.id);
     if(suppliesFor){
-      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--cyan);">${curSt.label}</strong></span>`+
+      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--accent);">${curSt.label}</strong></span>`+
         `<button class="cargo-btn load" style="margin-left:auto;" onclick="loadCargo()">Load supplies for ${suppliesFor.label}</button>`;
     } else {
       actionHtml='<span style="font-size:13px;color:var(--txtlo);">Nothing to load at this station</span>';
@@ -622,6 +665,7 @@ function renderLog(){
     </div>`;
   }).join('');
   liveLog.forEach(e=>e.fresh=false);
+  updateLogCount();
 }
 function selCorr(c){hlCorr=hlCorr===c?null:c;renderLog();}
 function hlRandom(){const e=liveLog[Math.floor(Math.random()*liveLog.length)];if(e)selCorr(e.corr);}
@@ -716,11 +760,11 @@ function drawMap(){
   ctx.clearRect(0,0,W,H);
 
   // background follows theme
-  ctx.fillStyle=lightMode?'#eef3f9':'#070f1c';
+  ctx.fillStyle=lightMode?'#f5f0eb':'#0f0d0b';
   ctx.fillRect(0,0,W,H);
 
   // grid
-  ctx.strokeStyle=lightMode?'rgba(0,120,180,.06)':'rgba(0,160,230,.04)';
+  ctx.strokeStyle=lightMode?'rgba(212,135,94,.06)':'rgba(212,135,94,.04)';
   ctx.lineWidth=1;
   for(let x=0;x<W;x+=70){ctx.beginPath();ctx.moveTo(x,0);ctx.lineTo(x,H);ctx.stroke();}
   for(let y=0;y<H;y+=70){ctx.beginPath();ctx.moveTo(0,y);ctx.lineTo(W,y);ctx.stroke();}
@@ -746,7 +790,7 @@ function drawMap(){
     const to=stationXY(dest);
     ctx.save();
     ctx.setLineDash([5,8]);
-    ctx.strokeStyle=lightMode?'rgba(0,120,180,.25)':'rgba(0,160,230,.22)';
+    ctx.strokeStyle=lightMode?'rgba(212,135,94,.25)':'rgba(212,135,94,.22)';
     ctx.lineWidth=1;
     ctx.beginPath();ctx.moveTo(from.x,from.y);ctx.lineTo(to.x,to.y);ctx.stroke();
     ctx.restore();
@@ -789,7 +833,7 @@ function drawMap(){
     // label
     ctx.font=`600 13px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'rgba(10,30,60,0.75)':'rgba(200,220,240,0.85)';
+    ctx.fillStyle=lightMode?'rgba(42,30,20,0.75)':'rgba(224,210,196,0.85)';
     ctx.fillText(st.label,x,y+r+18);
     // stock indicator
     const pct=Math.round(st.stock);
@@ -821,29 +865,29 @@ function drawMap(){
     ctx.beginPath();ctx.moveTo(-4,9);ctx.lineTo(4,9);ctx.lineTo(0,17+Math.sin(mapTick*0.35)*3);ctx.closePath();ctx.fill();
     ctx.globalAlpha=1;
     // hull
-    ctx.fillStyle='#4a90d9';
+    ctx.fillStyle='#c47a52';
     ctx.beginPath();ctx.moveTo(0,-14);ctx.lineTo(8,9);ctx.lineTo(0,5);ctx.lineTo(-8,9);ctx.closePath();ctx.fill();
     // cockpit
     ctx.fillStyle='#fff';ctx.beginPath();ctx.arc(0,-5,4,0,Math.PI*2);ctx.fill();
     ctx.restore();
     ctx.font=`600 12px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'#1a5fa8':'#85b7eb';
+    ctx.fillStyle=lightMode?'#8b5a3a':'#d4975e';
     ctx.fillText('VSS MERIDIAN',spx,spy+26);
   } else {
     // docked ship — draw on planet or at center
     ctx.save();ctx.translate(spx,spy);
-    ctx.fillStyle='#4a90d9';
+    ctx.fillStyle='#c47a52';
     ctx.beginPath();ctx.moveTo(0,-14);ctx.lineTo(8,9);ctx.lineTo(0,5);ctx.lineTo(-8,9);ctx.closePath();ctx.fill();
     ctx.fillStyle='#fff';ctx.beginPath();ctx.arc(0,-5,4,0,Math.PI*2);ctx.fill();
     ctx.restore();
     ctx.font=`600 12px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'#1a5fa8':'#85b7eb';
+    ctx.fillStyle=lightMode?'#8b5a3a':'#d4975e';
     ctx.fillText('VSS MERIDIAN',spx,spy+26);
     if(!meridian.stationId){
       ctx.font=`13px Inter, sans-serif`;
-      ctx.fillStyle=lightMode?'rgba(30,80,150,0.5)':'rgba(150,200,255,0.5)';
+      ctx.fillStyle=lightMode?'rgba(140,90,60,0.5)':'rgba(212,151,94,0.5)';
       ctx.fillText('click a planet to fly there',spx,spy+44);
     }
   }
@@ -851,22 +895,7 @@ function drawMap(){
 
 function renderMap(){drawMap();}  // kept for compat calls
 
-function updateDestBar(){
-  const ship=ships[0];
-  const bar=document.getElementById('destBar');
-  if(!bar)return;
-  if(ship.status==='transit'){
-    const dest=STATIONS.find(s=>s.id===ship.dest);
-    const cargoStr=ship.cargo>0?` · ${ship.cargo}t cargo`:'';
-    bar.innerHTML=`<span style="font-family:var(--mono);font-size:12px;color:var(--cyan);">▶ En route → ${dest?.label||'?'}${cargoStr}</span>`;
-    return;
-  }
-  bar.innerHTML=STATIONS.map(st=>{
-    const here=st.id===ship.stationId;
-    return`<button class="pill ${here?'pg':'pc'}" style="cursor:${here?'default':'pointer'};border:none;font-family:var(--mono);font-size:11px;padding:4px 12px;"
-      ${here?'':'onclick="userDepart(\''+st.id+'\')"'}>${here?'◉ '+st.label:st.label}</button>`;
-  }).join('');
-}
+function updateDestBar(){}
 
 function userDepart(destId){
   const ship=ships[0];
@@ -908,7 +937,7 @@ function onShipClick(e,id){
     <div class="pi-row"><span class="pi-k">Fuel</span><span class="pi-v a">${ship.fuel}%</span></div>
     <div class="pi-row"><span class="pi-k">Version</span><span class="pi-v c">v.${ship.ver}</span></div>
     <div class="snap-wrap">
-      <div class="snap-lbl"><span>Events since snapshot</span><span style="color:var(--cyandim)">${since}/50</span></div>
+      <div class="snap-lbl"><span>Events since snapshot</span><span style="color:var(--accentdim)">${since}/50</span></div>
       <div class="snap-track"><div class="snap-mark"></div><div class="snap-fill" style="width:${Math.min(100,since/50*100)}%"></div></div>
     </div>`;
 }

--- a/canon-demo/frontend/src/app.rs
+++ b/canon-demo/frontend/src/app.rs
@@ -63,17 +63,30 @@ pub fn App() -> impl IntoView {
         connect_ws(state);
     });
 
+    let live_style = move || {
+        if state.active_tab.get() == ActiveTab::LiveFleet {
+            "display:flex;flex:1;min-height:0;"
+        } else {
+            "display:none;"
+        }
+    };
+    let scenarios_style = move || {
+        if state.active_tab.get() == ActiveTab::Scenarios {
+            "display:flex;flex:1;min-height:0;"
+        } else {
+            "display:none;"
+        }
+    };
+
     view! {
         <div class="app-shell">
             <Header state=state />
-            {move || {
-                match state.active_tab.get() {
-                    ActiveTab::LiveFleet => view! { <LiveFleetPage state=state /> }.into_any(),
-                    ActiveTab::Scenarios => {
-                        view! { <ScenariosPage /> }.into_any()
-                    }
-                }
-            }}
+            <div style=live_style>
+                <LiveFleetPage state=state />
+            </div>
+            <div style=scenarios_style>
+                <ScenariosPage />
+            </div>
         </div>
     }
 }
@@ -106,7 +119,7 @@ fn Header(state: AppState) -> impl IntoView {
         <div class="header">
             <div class="header-left">
                 <div class="header-logo">
-                    "C" <span class="logo-a">"A"</span> "NON"
+                    "Canon"
                     <span class="logo-sub">"/ fleet ops demo"</span>
                 </div>
                 <div class="header-nav">

--- a/canon-demo/frontend/src/canvas_map.rs
+++ b/canon-demo/frontend/src/canvas_map.rs
@@ -31,7 +31,7 @@ const FLIGHT_DURATION_MS: f64 = 4200.0;
 pub struct ThemeColors {
     pub bg: String,
     pub grid: String,
-    pub cyan: String,
+    pub accent: String,
     pub green: String,
     pub amber: String,
     pub red: String,
@@ -58,16 +58,16 @@ pub struct ThemeColors {
 impl Default for ThemeColors {
     fn default() -> Self {
         Self {
-            bg: "#070f1c".into(),
-            grid: "rgba(0,160,230,0.032)".into(),
-            cyan: "#00b4ff".into(),
+            bg: "#0f0d0b".into(),
+            grid: "rgba(212,135,94,0.04)".into(),
+            accent: "#d4875e".into(),
             green: "#00e58a".into(),
             amber: "#f5a623".into(),
             red: "#ff4069".into(),
             purple: "#a78bfa".into(),
-            txt: "#9db8d2".into(),
-            txthi: "#daeaf8".into(),
-            txtlo: "#4e6a82".into(),
+            txt: "#a89888".into(),
+            txthi: "#e0d2c4".into(),
+            txtlo: "#6b5d50".into(),
             planet_green: "#3B6D11".into(),
             planet_purple: "#534AB7".into(),
             planet_coral: "#993C1D".into(),
@@ -76,7 +76,7 @@ impl Default for ThemeColors {
             ship_label: "#85b7eb".into(),
             ship_dead: "#8b4040".into(),
             ship_dead_label: "#cc6666".into(),
-            route_line: "rgba(0,160,230,0.22)".into(),
+            route_line: "rgba(212,135,94,0.22)".into(),
             star: "rgba(255,255,255,0.55)".into(),
             highlight_sheen: "rgba(255,255,255,0.12)".into(),
             label_text: "rgba(200,220,240,0.85)".into(),
@@ -121,7 +121,7 @@ pub fn read_theme_colors() -> ThemeColors {
             ThemeColors {
                 bg: read_css_var(&s, "--bg", &defaults.bg),
                 grid: read_css_var(&s, "--grid", &defaults.grid),
-                cyan: read_css_var(&s, "--cyan", &defaults.cyan),
+                accent: read_css_var(&s, "--accent", &defaults.accent),
                 green: read_css_var(&s, "--green", &defaults.green),
                 amber: read_css_var(&s, "--amber", &defaults.amber),
                 red: read_css_var(&s, "--red", &defaults.red),
@@ -158,9 +158,9 @@ pub fn resolve_planet_color<'a>(station: &StationDef, colors: &'a ThemeColors) -
         "--planet-blue" => &colors.planet_blue,
         other => {
             web_sys::console::warn_1(
-                &format!("Unknown planet_color_var: {other}, falling back to --cyan").into(),
+                &format!("Unknown planet_color_var: {other}, falling back to --accent").into(),
             );
-            &colors.cyan
+            &colors.accent
         }
     }
 }

--- a/canon-demo/frontend/src/hydrate.rs
+++ b/canon-demo/frontend/src/hydrate.rs
@@ -177,7 +177,7 @@ fn hydrate_stations(state: AppState, base: String, sid: String) {
             return;
         }
 
-        let stations: Vec<StationStateResponse> = match resp.json().await {
+        let mut stations: Vec<StationStateResponse> = match resp.json().await {
             Ok(s) => s,
             Err(_) => return,
         };
@@ -185,6 +185,17 @@ fn hydrate_stations(state: AppState, base: String, sid: String) {
         if stations.is_empty() {
             return; // keep demo defaults
         }
+
+        // Sort to match canonical order: Alpha, Beta, Gamma, Delta.
+        // This ensures positions, planet colours, and supply-chain links
+        // are assigned correctly regardless of API return order.
+        let canonical_order = ["Alpha Depot", "Beta Relay", "Gamma Outpost", "Delta Prime"];
+        stations.sort_by_key(|s| {
+            canonical_order
+                .iter()
+                .position(|&name| name == s.name)
+                .unwrap_or(usize::MAX)
+        });
 
         // Map gateway stations onto canonical positions.
         let positions = default_station_positions();
@@ -219,7 +230,7 @@ fn hydrate_stations(state: AppState, base: String, sid: String) {
                     top_pct: top,
                     stock_low,
                     stock_pct,
-                    planet_color_var: planet_color_vars.get(i).unwrap_or(&"--cyan").to_string(),
+                    planet_color_var: planet_color_vars.get(i).unwrap_or(&"--accent").to_string(),
                     planet_radius: planet_radii.get(i).copied().unwrap_or(20.0),
                     has_ring: has_rings.get(i).copied().unwrap_or(false),
                     capacity_kg: s.capacity_kg as f64,

--- a/canon-demo/frontend/src/pages/live_fleet.rs
+++ b/canon-demo/frontend/src/pages/live_fleet.rs
@@ -15,6 +15,26 @@ use crate::state::{
 };
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract just `HH:MM:SS.mmm` from an ISO timestamp string.
+fn format_time(ts: &str) -> String {
+    // Input like "2026-03-24T23:04:983797384+00:00" — grab the time part after 'T'
+    if let Some(t_pos) = ts.find('T') {
+        let after_t = &ts[t_pos + 1..];
+        // Take up to the timezone offset (+/- or Z)
+        let time_part = after_t.split(['+', 'Z']).next().unwrap_or(after_t);
+        // Truncate to HH:MM:SS.mmm (12 chars)
+        if time_part.len() > 12 {
+            return time_part[..12].to_string();
+        }
+        return time_part.to_string();
+    }
+    ts.to_string()
+}
+
+// ---------------------------------------------------------------------------
 // Supply chain game logic
 // ---------------------------------------------------------------------------
 
@@ -529,16 +549,20 @@ fn deliver_cargo(state: AppState) {
 
 #[component]
 pub fn LiveFleetPage(state: AppState) -> impl IntoView {
+    let log_open = RwSignal::new(false);
+
     view! {
         <div class="content-area">
-            <div class="map-wrap">
-                <ConnectionBanner state=state />
-                <MapBar state=state />
-                <MapCanvas state=state />
-                <StationCards state=state />
-                <ShipActionBar state=state />
+            <div class="live-main">
+                <div class="map-wrap">
+                    <ConnectionBanner state=state />
+                    <MapBar state=state log_open=log_open />
+                    <MapCanvas state=state />
+                    <StationCards state=state />
+                    <ShipActionBar state=state />
+                </div>
             </div>
-            <EventLogStrip state=state />
+            <EventLogPanel state=state log_open=log_open />
         </div>
     }
 }
@@ -592,11 +616,12 @@ fn ConnectionBanner(state: AppState) -> impl IntoView {
 }
 
 #[component]
-fn MapBar(state: AppState) -> impl IntoView {
+fn MapBar(state: AppState, log_open: RwSignal<bool>) -> impl IntoView {
     let ships = state.ships;
     let stations = state.stations;
     let pending = state.pending_command;
     let connection = state.connection;
+    let log_entries = state.log_entries;
 
     // Show transit status or destination buttons
     let is_transit = move || {
@@ -615,6 +640,16 @@ fn MapBar(state: AppState) -> impl IntoView {
             })
         })
     };
+
+    let toggle_class = move || {
+        if log_open.get() {
+            "log-toggle active"
+        } else {
+            "log-toggle"
+        }
+    };
+
+    let log_count = move || log_entries.with(|e| e.len());
 
     view! {
         <div class="map-bar">
@@ -680,6 +715,11 @@ fn MapBar(state: AppState) -> impl IntoView {
                     }
                 }}
             </div>
+            <button class=toggle_class on:click=move |_| log_open.update(|v| *v = !*v)>
+                <div class="dot"></div>
+                "Event Log "
+                <span class="log-count">{log_count}</span>
+            </button>
         </div>
     }
 }
@@ -1184,7 +1224,7 @@ fn OversightStrip(oversight: RwSignal<OversightState>) -> impl IntoView {
 
 /// Returns the CSS colour for a station stock percentage.
 /// Green (>50%), amber (25-50%), red (<25%). Uses CSS variables.
-fn stock_color_var(pct: f64) -> &'static str {
+pub fn stock_color_var(pct: f64) -> &'static str {
     if pct > 50.0 {
         "var(--green)"
     } else if pct > 25.0 {
@@ -1196,67 +1236,92 @@ fn stock_color_var(pct: f64) -> &'static str {
 
 #[component]
 fn StationCards(state: AppState) -> impl IntoView {
-    let stations = state.stations;
-    let ships = state.ships;
+    let stations_init = state.stations.get_untracked();
+
+    // Render static cards once, then update DOM directly via Effect.
+    // This bypasses a Leptos 0.7 issue where view closures don't re-render
+    // from signal updates made in JS WebSocket callbacks.
+    Effect::new(move |_| {
+        let st = state.stations.get();
+        let sh = state.ships.get();
+        let doc = match web_sys::window().and_then(|w| w.document()) {
+            Some(d) => d,
+            None => return,
+        };
+        for (idx, station) in st.iter().enumerate() {
+            let pct = station.stock_pct;
+            let color = stock_color_var(pct);
+
+            if let Some(el) = doc.get_element_by_id(&format!("stn-fill-{idx}")) {
+                let _ = el.set_attribute("style", &format!("width:{pct:.1}%;background:{color};"));
+            }
+            if let Some(el) = doc.get_element_by_id(&format!("stn-pct-{idx}")) {
+                el.set_text_content(Some(&format!("{pct:.1}%")));
+                let _ = el.set_attribute("style", &format!("color:{color};"));
+            }
+            if let Some(el) = doc.get_element_by_id(&format!("stn-card-{idx}")) {
+                let is_active = sh
+                    .iter()
+                    .any(|s| s.status == ShipStatus::Docked && s.current_station_idx == Some(idx));
+                let _ = el.set_attribute(
+                    "class",
+                    if is_active {
+                        "stn-card active-stn"
+                    } else {
+                        "stn-card"
+                    },
+                );
+            }
+        }
+    });
 
     view! {
         <div class="station-cards">
-            {move || {
-                let st = stations.get();
-                let sh = ships.get();
+            {stations_init
+                .iter()
+                .enumerate()
+                .map(|(idx, station)| {
+                    let pct = station.stock_pct;
+                    let color = stock_color_var(pct);
+                    let fill_style = format!("width:{pct:.1}%;background:{color};");
+                    let pct_style = format!("color:{color};");
+                    let pct_display = format!("{pct:.1}%");
+                    let name = station.name.clone();
+                    let supplied_by = station.supplied_by_name.clone();
+                    let card_id = format!("stn-card-{idx}");
+                    let fill_id = format!("stn-fill-{idx}");
+                    let pct_id = format!("stn-pct-{idx}");
+                    let state_click = state;
 
-                st.iter()
-                    .enumerate()
-                    .map(|(idx, station)| {
-                        // Highlight card if any non-dead ship is docked at this station
-                        let is_active = sh.iter().any(|s| {
-                            s.status == ShipStatus::Docked && s.current_station_idx == Some(idx)
-                        });
-                        let card_class = if is_active {
-                            "stn-card active-stn"
-                        } else {
-                            "stn-card"
-                        };
-                        let pct = station.stock_pct;
-                        let color = stock_color_var(pct);
-                        let fill_style = format!("width:{pct}%;background:{color};");
-                        let pct_style = format!("color:{color};");
-                        let pct_display = format!("{pct:.0}%");
-                        let supplied_by = station.supplied_by_name.clone();
-                        let name = station.name.clone();
-                        let state_click = state;
-                        let dest_idx = idx;
-
-                        view! {
-                            <div
-                                class=card_class
-                                on:click=move |_| {
-                                    // Fly the first live ship to this station (same as clicking planet)
-                                    let ships_data = state_click.ships.get_untracked();
-                                    if let Some(ship) = ships_data.first() {
-                                        if ship.status == ShipStatus::Transit {
-                                            return;
-                                        }
-                                        if ship.current_station_idx == Some(dest_idx) {
-                                            return;
-                                        }
-                                        depart_ship(state_click, 0, dest_idx);
+                    view! {
+                        <div
+                            id=card_id
+                            class="stn-card"
+                            on:click=move |_| {
+                                let ships_data = state_click.ships.get_untracked();
+                                if let Some(ship) = ships_data.first() {
+                                    if ship.status == ShipStatus::Transit {
+                                        return;
                                     }
+                                    if ship.current_station_idx == Some(idx) {
+                                        return;
+                                    }
+                                    depart_ship(state_click, 0, idx);
                                 }
-                            >
-                                <div class="stn-card-name">{name}</div>
-                                <div class="stn-card-sub">
-                                    {format!("Supplied from {supplied_by}")}
-                                </div>
-                                <div class="stn-card-bar">
-                                    <div class="stn-card-fill" style=fill_style></div>
-                                </div>
-                                <div class="stn-card-pct" style=pct_style>{pct_display}</div>
+                            }
+                        >
+                            <div class="stn-card-name">{name}</div>
+                            <div class="stn-card-sub">
+                                {format!("Supplied from {supplied_by}")}
                             </div>
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            }}
+                            <div class="stn-card-bar">
+                                <div id=fill_id class="stn-card-fill" style=fill_style></div>
+                            </div>
+                            <div id=pct_id class="stn-card-pct" style=pct_style>{pct_display}</div>
+                        </div>
+                    }
+                })
+                .collect_view()}
         </div>
     }
 }
@@ -1461,7 +1526,7 @@ fn ShipActionBar(state: AppState) -> impl IntoView {
 }
 
 #[component]
-fn EventLogStrip(state: AppState) -> impl IntoView {
+fn EventLogPanel(state: AppState, log_open: RwSignal<bool>) -> impl IntoView {
     let entries = state.log_entries;
     let highlighted = state.highlighted_corr;
 
@@ -1478,11 +1543,24 @@ fn EventLogStrip(state: AppState) -> impl IntoView {
         });
     };
 
+    let panel_class = move || {
+        if log_open.get() {
+            "log-panel open"
+        } else {
+            "log-panel"
+        }
+    };
+
     view! {
-        <div class="event-log-strip">
-            <div class="log-header">
-                <span class="bar-lbl">"Event log"</span>
-                <div class="live-badge"><div class="dot"></div>"Live"</div>
+        <div class=panel_class>
+            <div class="log-panel-hdr">
+                <div style="display:flex;align-items:center;gap:10px;">
+                    <span class="bar-lbl">"Event Log"</span>
+                    <div class="live-badge"><div class="dot"></div>"Live"</div>
+                </div>
+                <button class="log-panel-close" on:click=move |_| log_open.set(false)>
+                    "\u{2715} Close"
+                </button>
             </div>
             <div class="log-body">
                 <For
@@ -1494,8 +1572,8 @@ fn EventLogStrip(state: AppState) -> impl IntoView {
                 />
             </div>
             <div class="log-footer">
-                "Click any event to trace its correlation chain "
-                <a on:click=highlight_random>"(highlight random)"</a>
+                "Events are append-only \u{2014} "
+                <a on:click=highlight_random>"highlight random correlation"</a>
             </div>
         </div>
     }
@@ -1539,7 +1617,7 @@ fn LogEntryRow(entry: LogEntry, highlighted: RwSignal<Option<Uuid>>) -> impl Int
 
     view! {
         <div class=row_class on:click=on_click>
-            <span class="log-ts">{entry.timestamp.clone()}</span>
+            <span class="log-ts">{format_time(&entry.timestamp)}</span>
             <div class="log-row">
                 <span class=svc_class>{entry.service.clone()}</span>
                 <span class="log-name">{entry.event_name.clone()}</span>

--- a/canon-demo/frontend/src/scenarios/snapshot.rs
+++ b/canon-demo/frontend/src/scenarios/snapshot.rs
@@ -291,7 +291,7 @@ pub fn SnapshotScenario(close_signal: RwSignal<bool>) -> impl IntoView {
         if cold_done.get() {
             "color:var(--amber)"
         } else {
-            "color:var(--cyan)"
+            "color:var(--accent)"
         }
     };
 
@@ -387,7 +387,7 @@ pub fn SnapshotScenario(close_signal: RwSignal<bool>) -> impl IntoView {
                             if hot_done.get() {
                                 "color:var(--green);animation:flash 0.4s ease-out;"
                             } else {
-                                "color:var(--cyan)"
+                                "color:var(--accent)"
                             }
                         }
                     >

--- a/canon-demo/frontend/src/state.rs
+++ b/canon-demo/frontend/src/state.rs
@@ -48,7 +48,7 @@ pub struct ShipState {
     pub flight_duration_ms: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StationDef {
     pub id: Uuid,
     pub name: String,

--- a/canon-demo/frontend/src/ws.rs
+++ b/canon-demo/frontend/src/ws.rs
@@ -519,23 +519,34 @@ fn handle_game_event(state: AppState, live_event: &LiveEvent) {
 
                 if let (Some(sid), Some(remaining)) = (station_id, remaining_kg) {
                     let mut any_depleted = false;
+                    let mut updated_idx: Option<usize> = None;
+                    let mut new_pct = 0.0_f64;
 
                     state.stations.update(|stations| {
-                        if let Some(station) = stations.iter_mut().find(|s| s.id == sid) {
-                            // Convert remaining_kg to percentage of capacity.
+                        if let Some((idx, station)) =
+                            stations.iter_mut().enumerate().find(|(_, s)| s.id == sid)
+                        {
                             let capacity = if station.capacity_kg > 0.0 {
                                 station.capacity_kg
                             } else {
-                                5000.0 // fallback for stations hydrated before capacity was known
+                                5000.0
                             };
-                            station.stock_pct = (remaining / capacity * 100.0).max(0.0);
+                            station.stock_pct = (remaining / capacity * 100.0).clamp(0.0, 100.0);
                             station.stock_low = station.stock_pct < STOCK_LOW_THRESHOLD;
+                            new_pct = station.stock_pct;
+                            updated_idx = Some(idx);
 
                             if station.stock_pct <= 0.0 {
                                 any_depleted = true;
                             }
                         }
                     });
+
+                    // Update the DOM synchronously so the card changes the
+                    // instant the event appears in the log — no async Effect delay.
+                    if let Some(idx) = updated_idx {
+                        update_station_card_dom(idx, new_pct);
+                    }
 
                     if any_depleted && !state.game_over.get_untracked() {
                         state.game_over.set(true);
@@ -547,12 +558,16 @@ fn handle_game_event(state: AppState, live_event: &LiveEvent) {
         "CargoUnloaded" | "CargoReceived" => {
             // Delivery confirmed by the pipeline -- replenish station stock.
             if let Some(cargo) = state.cargo.get_untracked() {
+                let dest_idx = cargo.destination_idx;
+                let mut new_pct = 0.0;
                 state.stations.update(|stations| {
-                    if let Some(station) = stations.get_mut(cargo.destination_idx) {
+                    if let Some(station) = stations.get_mut(dest_idx) {
                         station.stock_pct = (station.stock_pct + REPLENISH_AMOUNT).min(100.0);
                         station.stock_low = station.stock_pct < STOCK_LOW_THRESHOLD;
+                        new_pct = station.stock_pct;
                     }
                 });
+                update_station_card_dom(dest_idx, new_pct);
                 state.cargo.set(None);
             }
             state.pending_command.set(PendingCommand::None);
@@ -623,5 +638,24 @@ fn update_oversight_from_event(state: AppState, event: &LiveEvent) {
             });
         }
         _ => {}
+    }
+}
+
+/// Synchronously update a station card's DOM elements by index.
+/// Called directly from the WS message handler so the card updates
+/// in the same frame as the event log entry — no async Effect delay.
+fn update_station_card_dom(idx: usize, pct: f64) {
+    let pct = pct.clamp(0.0, 100.0);
+    let doc = match web_sys::window().and_then(|w| w.document()) {
+        Some(d) => d,
+        None => return,
+    };
+    let color = crate::pages::live_fleet::stock_color_var(pct);
+    if let Some(el) = doc.get_element_by_id(&format!("stn-fill-{idx}")) {
+        let _ = el.set_attribute("style", &format!("width:{pct:.1}%;background:{color};"));
+    }
+    if let Some(el) = doc.get_element_by_id(&format!("stn-pct-{idx}")) {
+        el.set_text_content(Some(&format!("{pct:.1}%")));
+        let _ = el.set_attribute("style", &format!("color:{color};"));
     }
 }

--- a/canon-demo/frontend/style/main.css
+++ b/canon-demo/frontend/style/main.css
@@ -1,21 +1,23 @@
-/* ===== Canon Design System ===== */
+/* ===== Canon Design System — Copper Theme ===== */
 :root {
-  --bg:#070f1c; --panel:#0d1e33; --raised:#112540;
-  --border:rgba(0,160,230,.18); --borderhi:rgba(0,160,230,.45);
-  --cyan:#00b4ff; --cyandim:rgba(0,180,255,.5);
+  --bg:#0f0d0b; --panel:#1a1614; --raised:#231e1a;
+  --border:rgba(212,135,94,.18); --borderhi:rgba(212,135,94,.45);
+  --accent:#d4875e; --accentdim:rgba(212,135,94,.5);
   --green:#00e58a; --greendim:rgba(0,229,138,.55);
   --amber:#f5a623; --amberdim:rgba(245,166,35,.55);
   --red:#ff4069; --reddim:rgba(255,64,105,.55);
   --purple:#a78bfa;
-  --txt:#9db8d2; --txthi:#daeaf8; --txtlo:#4e6a82;
-  --grid:rgba(0,160,230,.032);
-  --logbg:rgba(0,160,230,.05); --loglit:rgba(0,160,230,.09); --logorig:rgba(0,160,230,.15);
-  --divclr:rgba(0,160,230,.07);
-  --shadow:rgba(0,0,0,.45);
+  --txt:#a89888; --txthi:#e0d2c4; --txtlo:#6b5d50;
+  --grid:rgba(212,135,94,.04);
+  --logbg:rgba(212,135,94,.05); --loglit:rgba(212,135,94,.09); --logorig:rgba(212,135,94,.15);
+  --divclr:rgba(212,135,94,.07);
+  --shadow:rgba(0,0,0,.55);
   --badge-amber-bg:rgba(245,166,35,.15);
   --badge-green-bg:rgba(0,229,138,.15);
   --mono:'JetBrains Mono',monospace;
   --sans:'Inter',sans-serif;
+  --body:'Inter',sans-serif;
+  --copper:#d4875e;
   /* Canvas-specific colours */
   --planet-green:#3B6D11;
   --planet-purple:#534AB7;
@@ -25,7 +27,7 @@
   --ship-label:#85b7eb;
   --ship-dead:#8b4040;
   --ship-dead-label:#cc6666;
-  --route-line:rgba(0,160,230,.22);
+  --route-line:rgba(212,135,94,.22);
   --star:rgba(255,255,255,.55);
   --highlight-sheen:rgba(255,255,255,.12);
   --label-text:rgba(200,220,240,.85);
@@ -33,20 +35,21 @@
 }
 
 body.light {
-  --bg:#eef3f9; --panel:#fff; --raised:#f4f8fd;
-  --border:rgba(0,120,180,.15); --borderhi:rgba(0,120,180,.4);
-  --cyan:#0086cc; --cyandim:rgba(0,134,204,.55);
+  --bg:#f5f0eb; --panel:#fff; --raised:#faf6f2;
+  --border:rgba(176,102,74,.15); --borderhi:rgba(176,102,74,.4);
+  --accent:#b0664a; --accentdim:rgba(176,102,74,.55);
   --green:#00a86b; --greendim:rgba(0,168,107,.6);
   --amber:#d4820a; --amberdim:rgba(212,130,10,.6);
   --red:#d42e55; --reddim:rgba(212,46,85,.6);
   --purple:#7c3aed;
-  --txt:#3d5a7a; --txthi:#0f2a45; --txtlo:#7a9ab8;
-  --grid:rgba(0,120,180,.06);
-  --logbg:rgba(0,120,180,.04); --loglit:rgba(0,120,180,.08); --logorig:rgba(0,120,180,.14);
-  --divclr:rgba(0,120,180,.1);
+  --txt:#5a4a3e; --txthi:#2a1e14; --txtlo:#9a8878;
+  --grid:rgba(176,102,74,.06);
+  --logbg:rgba(176,102,74,.04); --loglit:rgba(176,102,74,.08); --logorig:rgba(176,102,74,.14);
+  --divclr:rgba(176,102,74,.1);
   --shadow:rgba(0,0,0,.12);
   --badge-amber-bg:rgba(212,130,10,.15);
   --badge-green-bg:rgba(0,168,107,.15);
+  --copper:#b0664a;
   /* Canvas-specific colours (light overrides) */
   --planet-green:#3B6D11;
   --planet-purple:#534AB7;
@@ -56,7 +59,7 @@ body.light {
   --ship-label:#1a5fa8;
   --ship-dead:#8b4040;
   --ship-dead-label:#994444;
-  --route-line:rgba(0,120,180,.25);
+  --route-line:rgba(176,102,74,.25);
   --star:rgba(255,255,255,.55);
   --highlight-sheen:rgba(255,255,255,.12);
   --label-text:rgba(10,30,60,.75);
@@ -66,11 +69,14 @@ body.light {
 * { margin:0; padding:0; box-sizing:border-box; }
 
 body {
-  font-family: var(--sans);
   background: var(--bg);
   color: var(--txt);
-  min-height: 100vh;
+  font-family: var(--sans);
+  height: 100vh;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: background .3s, color .3s;
 }
 
 /* Starfield */
@@ -103,16 +109,19 @@ body.light::before { opacity: 0; }
   z-index: 1;
 }
 
-/* Header */
+/* ===== Header ===== */
 .header {
+  position: relative;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 56px;
   padding: 0 24px;
+  height: 56px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  transition: background .3s, border-color .3s;
 }
 
 .header-left {
@@ -122,24 +131,24 @@ body.light::before { opacity: 0; }
 }
 
 .header-logo {
-  font-family: var(--sans);
-  font-weight: 800;
-  font-size: 20px;
-  color: var(--txthi);
-  letter-spacing: .02em;
-  white-space: nowrap;
-}
-
-.header-logo .logo-a {
-  color: var(--cyan);
+  font-family: 'Josefin Sans', sans-serif;
+  font-weight: 300;
+  font-size: 22px;
+  color: var(--copper);
+  user-select: none;
+  transition: color .3s;
+  letter-spacing: .32em;
+  text-transform: uppercase;
 }
 
 .header-logo .logo-sub {
-  color: var(--txtlo);
-  font-weight: 400;
+  font-family: var(--sans);
   font-size: 12px;
-  margin-left: 10px;
+  color: var(--txtlo);
+  margin-left: 12px;
+  font-weight: 400;
   text-transform: none;
+  letter-spacing: normal;
 }
 
 .header-nav {
@@ -149,26 +158,27 @@ body.light::before { opacity: 0; }
   height: 100%;
 }
 
+/* NAV TABS — inline in header */
 .nav-tab {
+  padding: 0 4px;
+  height: 56px;
   display: inline-flex;
   align-items: center;
-  height: 56px;
-  padding: 0 4px;
-  margin: 0 8px;
   font-family: var(--sans);
-  font-weight: 600;
   font-size: 14px;
+  font-weight: 600;
   color: var(--txtlo);
-  border-bottom: 2px solid transparent;
   cursor: pointer;
+  border-bottom: 2px solid transparent;
   transition: color .15s, border-color .15s;
+  margin: 0 8px;
   user-select: none;
 }
 
 .nav-tab:hover { color: var(--txt); }
 .nav-tab.active {
-  color: var(--cyan);
-  border-bottom-color: var(--cyan);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .header-right {
@@ -244,8 +254,8 @@ body.light::before { opacity: 0; }
 }
 
 body:not(.light) .toggle-track {
-  background: var(--cyan);
-  border-color: var(--cyan);
+  background: var(--accent);
+  border-color: var(--accent);
 }
 
 .toggle-thumb {
@@ -271,10 +281,20 @@ body:not(.light) .toggle-thumb {
 /* ===== Content area ===== */
 .content-area {
   display: flex;
-  flex-direction: column;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   position: relative;
+}
+
+/* ===== Live page — full-width column ===== */
+.live-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  transition: flex .3s cubic-bezier(.4,0,.2,1);
 }
 
 /* ===== Map wrap & bar ===== */
@@ -284,7 +304,6 @@ body:not(.light) .toggle-thumb {
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  background: var(--bg);
 }
 
 /* ===== Connection Banner ===== */
@@ -384,12 +403,12 @@ body:not(.light) .toggle-thumb {
 
 .dest-tab:hover:not(:disabled) {
   color: var(--txthi);
-  background: rgba(0,120,180,.06);
+  background: rgba(212,135,94,.06);
 }
 
 .dest-tab.active {
   background: var(--raised);
-  color: var(--cyan);
+  color: var(--accent);
   cursor: default;
 }
 
@@ -401,7 +420,7 @@ body:not(.light) .toggle-thumb {
 .transit-indicator {
   font-family: var(--mono);
   font-size: 12px;
-  color: var(--cyan);
+  color: var(--accent);
 }
 
 /* ===== Map canvas ===== */
@@ -410,12 +429,8 @@ body:not(.light) .toggle-thumb {
   position: relative;
   overflow: hidden;
   cursor: pointer;
+  min-height: 0;
 }
-
-/* Grid, stars, stations, ships, route lines all drawn on <canvas> now.
-   No CSS grid background, no SVG overlay, no DOM station/ship markers. */
-
-/* Ship marker/SVG classes removed — all rendering on canvas now. */
 
 /* ===== Ship popup ===== */
 .cmd-popup {
@@ -438,7 +453,7 @@ body:not(.light) .toggle-thumb {
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, var(--cyan), transparent);
+  background: linear-gradient(90deg, var(--accent), transparent);
   border-radius: 4px 4px 0 0;
 }
 
@@ -460,7 +475,7 @@ body:not(.light) .toggle-thumb {
 .popup-hint {
   font-family: var(--mono);
   font-size: 11px;
-  color: var(--cyandim);
+  color: var(--accentdim);
   margin-bottom: 8px;
 }
 
@@ -487,13 +502,13 @@ body:not(.light) .toggle-thumb {
 }
 
 .dest-btn:hover {
-  background: rgba(0,120,180,.06);
+  background: rgba(212,135,94,.06);
   border-color: var(--borderhi);
   color: var(--txthi);
 }
 
 .dest-btn .arr {
-  color: var(--cyandim);
+  color: var(--accentdim);
   font-size: 14px;
 }
 
@@ -524,7 +539,7 @@ body:not(.light) .toggle-thumb {
 
 .pi-k { color: var(--txtlo); }
 .pi-v { color: var(--txthi); }
-.pi-v.c { color: var(--cyan); }
+.pi-v.c { color: var(--accent); }
 .pi-v.a { color: var(--amber); }
 .pi-v.g { color: var(--green); }
 
@@ -551,7 +566,7 @@ body:not(.light) .toggle-thumb {
 
 .snap-fill {
   height: 100%;
-  background: var(--cyan);
+  background: var(--accent);
   border-radius: 2px;
   transition: width .4s;
 }
@@ -575,7 +590,7 @@ body:not(.light) .toggle-thumb {
 }
 
 .popup-info .snap-lbl .snap-count {
-  color: var(--cyandim);
+  color: var(--accentdim);
 }
 
 /* ===== Oversight strip ===== */
@@ -592,7 +607,7 @@ body:not(.light) .toggle-thumb {
   transition: opacity .4s, transform .4s, background .3s, border-color .3s;
 }
 body:not(.light) .os-strip {
-  background: rgba(7,15,28,.92);
+  background: rgba(15,13,11,.92);
 }
 
 .os-strip.hidden {
@@ -700,7 +715,7 @@ body:not(.light) .os-req.met .ic {
 
 .stn-card.active-stn {
   background: var(--raised);
-  border-top: 3px solid var(--cyan);
+  border-top: 3px solid var(--accent);
 }
 
 .stn-card-name {
@@ -828,7 +843,111 @@ body.light .restart-btn:hover {
   background: rgba(212, 46, 85, 0.08);
 }
 
-/* ===== Event Log Strip ===== */
+/* ===== Event Log — inline sliding panel ===== */
+.log-panel {
+  width: 0;
+  overflow: hidden;
+  background: var(--panel);
+  border-left: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  transition: width .3s cubic-bezier(.4,0,.2,1), border-color .3s;
+}
+.log-panel.open {
+  width: 380px;
+  border-left-color: var(--border);
+}
+.log-panel-hdr {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  min-width: 380px;
+}
+.log-panel-hdr .bar-lbl {
+  font-size: 14px;
+  font-weight: 700;
+}
+.log-panel-close {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--txtlo);
+  cursor: pointer;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  transition: all .15s;
+  background: transparent;
+}
+.log-panel-close:hover {
+  border-color: var(--borderhi);
+  color: var(--txt);
+}
+.log-panel .log-body {
+  flex: 1;
+  max-height: none !important;
+  overflow-y: auto;
+  min-width: 380px;
+}
+.log-panel .log-footer {
+  margin-top: auto;
+  min-width: 380px;
+}
+
+.log-toggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--txtlo);
+  cursor: pointer;
+  padding: 5px 14px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  transition: all .15s;
+  background: transparent;
+  user-select: none;
+}
+.log-toggle:hover {
+  border-color: var(--borderhi);
+  color: var(--txt);
+}
+.log-toggle.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.log-toggle .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+  animation: blink 2s ease-in-out infinite;
+}
+
+.log-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: rgba(212,135,94,.15);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 0 5px;
+}
+
+/* Legacy event-log-strip (bottom strip) — keep for backward compat */
 .event-log-strip {
   display: flex;
   flex-direction: column;
@@ -907,7 +1026,7 @@ body.light .restart-btn:hover {
 
 .log-item.lit {
   background: var(--loglit);
-  border-left-color: var(--cyan);
+  border-left-color: var(--accent);
 }
 
 .log-item.fresh {
@@ -915,7 +1034,7 @@ body.light .restart-btn:hover {
 }
 
 @keyframes flash {
-  0% { background: rgba(0,180,255,.22); }
+  0% { background: rgba(212,135,94,.18); }
   100% { background: transparent; }
 }
 
@@ -963,13 +1082,13 @@ body.light .restart-btn:hover {
   font-weight: 600;
 }
 
-.sf { background: rgba(0,180,255,.12); color: var(--cyan); }
+.sf { background: rgba(212,135,94,.12); color: var(--accent); }
 .sc { background: rgba(167,139,250,.14); color: var(--purple); }
 .sn { background: rgba(0,229,138,.11); color: var(--green); }
 .ss { background: rgba(245,166,35,.12); color: var(--amber); }
 .su { background: rgba(255,64,105,.11); color: var(--red); }
 
-body.light .sf { background: rgba(0,120,180,.12); color: #005fa8; }
+body.light .sf { background: rgba(176,102,74,.12); color: #8b5a3a; }
 body.light .sc { background: rgba(124,58,237,.12); color: #5b21b6; }
 body.light .sn { background: rgba(0,168,107,.12); color: #00694a; }
 body.light .ss { background: rgba(212,130,10,.12); color: #92570a; }
@@ -984,15 +1103,13 @@ body.light .su { background: rgba(212,46,85,.12); color: #991b3d; }
 }
 
 .log-footer a {
-  color: var(--cyandim);
+  color: var(--accentdim);
   text-decoration: none;
   cursor: pointer;
 }
 .log-footer a:hover {
-  color: var(--cyan);
+  color: var(--accent);
 }
-
-/* SVG route lines removed — drawn on canvas now. */
 
 /* ===== Utility ===== */
 
@@ -1030,9 +1147,9 @@ body.light .su { background: rgba(212,46,85,.12); color: #991b3d; }
 .pipeline-arrow{display:flex;flex-direction:column;align-items:center;height:28px;position:relative;width:100%;opacity:.3;transition:opacity .3s ease;}
 .pipeline-arrow.active{opacity:1;}
 .pipeline-arrow-line{width:1px;height:20px;background:var(--border);margin:0 auto;}
-.pipeline-arrow.active .pipeline-arrow-line{background:var(--cyan);}
+.pipeline-arrow.active .pipeline-arrow-line{background:var(--accent);}
 .pipeline-arrow-dot{width:6px;height:6px;border-radius:50%;background:var(--border);margin:0 auto;}
-.pipeline-arrow.active .pipeline-arrow-dot{background:var(--cyan);box-shadow:0 0 6px var(--cyan);animation:travel-dot .5s ease-out;}
+.pipeline-arrow.active .pipeline-arrow-dot{background:var(--accent);box-shadow:0 0 6px var(--accent);animation:travel-dot .5s ease-out;}
 @keyframes travel-dot{0%{transform:translateY(-20px);opacity:0}100%{transform:translateY(0);opacity:1}}
 
 .pipeline-summary{font-family:var(--mono);font-size:10px;color:var(--txtlo);text-align:center;margin-top:16px;animation:fade-in .5s ease;}
@@ -1045,7 +1162,7 @@ body.light .su { background: rgba(212,46,85,.12); color: #991b3d; }
 .idem-card-type{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--txthi);margin-bottom:8px;}
 .idem-card-mid{font-family:var(--mono);font-size:9px;margin-bottom:10px;}
 .idem-mid-label{color:var(--txtlo);margin-right:4px;}
-.idem-mid-value{color:var(--cyan);}
+.idem-mid-value{color:var(--accent);}
 
 .idem-badge{font-family:var(--mono);font-size:9px;padding:2px 8px;border-radius:2px;display:inline-block;}
 .idem-pending{background:rgba(245,166,35,.12);color:var(--amber);}
@@ -1059,8 +1176,8 @@ body.light .su { background: rgba(212,46,85,.12); color: #991b3d; }
 .idem-conflict-note{font-family:var(--mono);font-size:9px;color:var(--txtlo);background:var(--raised);border:1px solid var(--border);padding:8px 12px;max-width:480px;width:100%;animation:fade-in .4s ease;}
 
 /* ══════════ SCENARIO RUNNER ══════════ */
-.sc-runner{display:none;position:fixed;inset:0;z-index:100;background:rgba(7,15,28,.97);flex-direction:column;overflow:hidden;}
-body.light .sc-runner{background:rgba(238,243,249,.98);}
+.sc-runner{display:none;position:fixed;inset:0;z-index:100;background:rgba(15,13,11,.97);flex-direction:column;overflow:hidden;}
+body.light .sc-runner{background:rgba(245,240,235,.98);}
 .sc-runner.open{display:flex;}
 .sc-runner-hdr{display:flex;align-items:center;justify-content:space-between;padding:16px 28px;border-bottom:1px solid var(--border);flex-shrink:0;background:var(--panel);}
 .sc-runner-title{font-family:var(--sans);font-size:17px;font-weight:700;color:var(--txthi);}
@@ -1076,11 +1193,11 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .step{display:flex;align-items:center;gap:0;}
 .step-dot{width:28px;height:28px;border-radius:50%;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:11px;color:var(--txtlo);flex-shrink:0;transition:all .3s;}
 .step.done .step-dot{background:var(--green);border-color:var(--green);color:#fff;}
-.step.active .step-dot{background:var(--cyan);border-color:var(--cyan);color:#fff;box-shadow:0 0 10px var(--cyandim);}
+.step.active .step-dot{background:var(--accent);border-color:var(--accent);color:#fff;box-shadow:0 0 10px var(--accentdim);}
 .step-line{width:28px;height:1px;background:var(--border);flex-shrink:0;}
 .step.done .step-line{background:var(--green);}
 .step-lbl{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-left:8px;white-space:nowrap;}
-.step.active .step-lbl{color:var(--cyan);}
+.step.active .step-lbl{color:var(--accent);}
 .step.done  .step-lbl{color:var(--greendim);}
 .step-gap{width:16px;flex-shrink:0;}
 
@@ -1089,9 +1206,9 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .sc-narr-title{font-family:var(--sans);font-size:16px;font-weight:700;color:var(--txthi);margin-bottom:8px;}
 .sc-narr-body{font-family:var(--sans);font-size:14px;color:var(--txt);line-height:1.65;max-width:620px;}
 .sc-action-area{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:28px;gap:18px;}
-.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--cyan);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--cyan);}
-.sc-big-btn:hover{background:rgba(0,120,180,.08);box-shadow:0 0 20px rgba(0,120,180,.15);}
+.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--accent);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
+.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--accent);}
+.sc-big-btn:hover{background:rgba(212,135,94,.08);box-shadow:0 0 20px rgba(212,135,94,.15);}
 .sc-big-btn:disabled{opacity:.4;cursor:not-allowed;}
 .sc-sub-btn{font-family:var(--mono);font-size:12px;padding:9px 22px;border:1px solid var(--border);background:transparent;color:var(--txt);cursor:pointer;transition:all .2s;border-radius:3px;}
 .sc-sub-btn:hover{border-color:var(--borderhi);color:var(--txthi);}
@@ -1099,7 +1216,7 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 /* ══════════ SCENARIO LOG ITEMS ══════════ */
 .sc-log-inner .log-item{padding:6px 14px;border-left:2px solid transparent;cursor:pointer;transition:background .12s,border-color .12s;}
 .sc-log-inner .log-item:hover{background:var(--logbg);}
-.sc-log-inner .log-item.lit{background:var(--loglit);border-left-color:var(--cyan);}
+.sc-log-inner .log-item.lit{background:var(--loglit);border-left-color:var(--accent);}
 .sc-log-inner .log-item.lit.orig{background:var(--logorig);}
 .sc-log-inner .log-item.fresh{animation:flash .6s ease-out;}
 .sc-log-inner .log-ts{font-family:var(--mono);font-size:9px;color:var(--txtlo);margin-bottom:2px;}
@@ -1111,10 +1228,10 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 
 /* ══════════ HYDRATION VIZ (Mission 02) ══════════ */
 .hydrate-viz{width:100%;max-width:400px;text-align:center;}
-.hv-counter{font-family:var(--mono);font-size:48px;color:var(--cyan);line-height:1;margin-bottom:8px;transition:color .3s;}
+.hv-counter{font-family:var(--mono);font-size:48px;color:var(--accent);line-height:1;margin-bottom:8px;transition:color .3s;}
 .hv-label{font-family:var(--mono);font-size:12px;color:var(--txtlo);margin-bottom:16px;}
 .hv-bar{height:5px;background:var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px;}
-.hv-fill{height:100%;background:var(--cyan);transition:width .05s linear;}
+.hv-fill{height:100%;background:var(--accent);transition:width .05s linear;}
 .hv-status{font-family:var(--mono);font-size:12px;color:var(--txtlo);}
 
 /* ══════════ PERFORMANCE VIZ (Mission 02) ══════════ */
@@ -1155,17 +1272,17 @@ body:not(.light) .gv-rdy{color:var(--green);}
 
 .sc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:18px;padding:28px 40px;}
 .sc-card{background:var(--panel);border:1px solid var(--border);padding:22px 24px;cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--cyan),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
+.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--accent),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
 .sc-card:hover{border-color:var(--borderhi);box-shadow:0 4px 20px var(--shadow);}
 .sc-card:hover::before{opacity:1;}
-.sc-card.active{border-color:var(--cyan);background:var(--raised);}
+.sc-card.active{border-color:var(--accent);background:var(--raised);}
 .sc-card.active::before{opacity:1;}
 .sc-num{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:8px;}
 .sc-name{font-family:var(--sans);font-size:18px;font-weight:700;color:var(--txthi);margin-bottom:6px;}
-.sc-ship{font-family:var(--mono);font-size:12px;color:var(--cyan);margin-bottom:10px;}
+.sc-ship{font-family:var(--mono);font-size:12px;color:var(--accent);margin-bottom:10px;}
 .sc-desc{font-family:var(--sans);font-size:13px;color:var(--txt);line-height:1.6;margin-bottom:12px;}
 .sc-tags{display:flex;flex-wrap:wrap;gap:6px;}
 .sc-tag{font-family:var(--mono);font-size:10px;padding:3px 9px;border-radius:3px;background:var(--raised);color:var(--txtlo);border:1px solid var(--border);}
 body.light .sc-tag{background:var(--bg);}
-.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--cyan);cursor:pointer;transition:all .2s;border-radius:3px;}
-.sc-launch:hover{background:rgba(0,120,180,.08);}
+.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--accent);cursor:pointer;transition:all .2s;border-radius:3px;}
+.sc-launch:hover{background:rgba(212,135,94,.08);}

--- a/canon-demo/gateway/Cargo.toml
+++ b/canon-demo/gateway/Cargo.toml
@@ -33,3 +33,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures     = { workspace = true }
 rskafka     = { workspace = true }
 sqlx        = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json", "derive"] }
+rand        = "0.8"

--- a/canon-demo/gateway/src/session.rs
+++ b/canon-demo/gateway/src/session.rs
@@ -228,7 +228,10 @@ pub fn spawn_session_drain(station_pool: PgPool, station_ids: [Uuid; 4]) -> Join
 
             for (i, station_id) in station_ids.iter().enumerate() {
                 let drain_cfg = &STATION_DRAIN_CONFIGS[i];
-                let drain_kg = (drain_cfg.capacity_kg * drain_cfg.drain_rate_pct / 100.0) as f32;
+                // Random drain between 1% and 5% of capacity per tick
+                use rand::Rng;
+                let pct = rand::thread_rng().gen_range(1.0_f64..=5.0);
+                let drain_kg = (drain_cfg.capacity_kg * pct / 100.0) as f32;
 
                 #[derive(serde::Serialize)]
                 struct DrainPayload {

--- a/canon-demo/station-service/src/events.rs
+++ b/canon-demo/station-service/src/events.rs
@@ -80,7 +80,7 @@ impl ShipDocked {
 #[canon_core::event_combiner(Station, version = 1)]
 impl CargoReceived {
     fn combine(&self, state: &mut Station) {
-        state.current_stock_kg += self.weight_kg;
+        state.current_stock_kg = (state.current_stock_kg + self.weight_kg).min(state.capacity_kg);
     }
 }
 

--- a/mockup.html
+++ b/mockup.html
@@ -4,36 +4,38 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Canon — Fleet Ops Demo</title>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
 <style>
 :root {
-  --bg:#070f1c; --panel:#0d1e33; --raised:#112540;
-  --border:rgba(0,160,230,.18); --borderhi:rgba(0,160,230,.45);
-  --cyan:#00b4ff; --cyandim:rgba(0,180,255,.5);
+  --bg:#0f0d0b; --panel:#1a1614; --raised:#231e1a;
+  --border:rgba(212,135,94,.18); --borderhi:rgba(212,135,94,.45);
+  --accent:#d4875e; --accentdim:rgba(212,135,94,.5);
   --green:#00e58a; --greendim:rgba(0,229,138,.55);
   --amber:#f5a623; --amberdim:rgba(245,166,35,.55);
   --red:#ff4069; --reddim:rgba(255,64,105,.55);
   --purple:#a78bfa;
-  --txt:#9db8d2; --txthi:#daeaf8; --txtlo:#4e6a82;
-  --grid:rgba(0,160,230,.032);
-  --logbg:rgba(0,160,230,.05); --loglit:rgba(0,160,230,.09); --logorig:rgba(0,160,230,.15);
-  --divclr:rgba(0,160,230,.07);
-  --shadow:rgba(0,0,0,.45);
+  --txt:#a89888; --txthi:#e0d2c4; --txtlo:#6b5d50;
+  --grid:rgba(212,135,94,.04);
+  --logbg:rgba(212,135,94,.05); --loglit:rgba(212,135,94,.09); --logorig:rgba(212,135,94,.15);
+  --divclr:rgba(212,135,94,.07);
+  --shadow:rgba(0,0,0,.55);
   --mono:'JetBrains Mono',monospace; --sans:'Inter',sans-serif; --body:'Inter',sans-serif;
+  --copper:#d4875e;
 }
 body.light {
-  --bg:#eef3f9; --panel:#fff; --raised:#f4f8fd;
-  --border:rgba(0,120,180,.15); --borderhi:rgba(0,120,180,.4);
-  --cyan:#0086cc; --cyandim:rgba(0,134,204,.55);
+  --bg:#f5f0eb; --panel:#fff; --raised:#faf6f2;
+  --border:rgba(176,102,74,.15); --borderhi:rgba(176,102,74,.4);
+  --accent:#b0664a; --accentdim:rgba(176,102,74,.55);
   --green:#00a86b; --greendim:rgba(0,168,107,.6);
   --amber:#d4820a; --amberdim:rgba(212,130,10,.6);
   --red:#d42e55; --reddim:rgba(212,46,85,.6);
   --purple:#7c3aed;
-  --txt:#3d5a7a; --txthi:#0f2a45; --txtlo:#7a9ab8;
-  --grid:rgba(0,120,180,.06);
-  --logbg:rgba(0,120,180,.04); --loglit:rgba(0,120,180,.08); --logorig:rgba(0,120,180,.14);
-  --divclr:rgba(0,120,180,.1);
+  --txt:#5a4a3e; --txthi:#2a1e14; --txtlo:#9a8878;
+  --grid:rgba(176,102,74,.06);
+  --logbg:rgba(176,102,74,.04); --loglit:rgba(176,102,74,.08); --logorig:rgba(176,102,74,.14);
+  --divclr:rgba(176,102,74,.1);
   --shadow:rgba(0,0,0,.12);
+  --copper:#b0664a;
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--txt);font-family:var(--sans);height:100vh;overflow:hidden;display:flex;flex-direction:column;transition:background .3s,color .3s;}
@@ -42,9 +44,8 @@ body.light::before{opacity:0;}
 
 /* HEADER */
 header{position:relative;z-index:20;display:flex;align-items:center;justify-content:space-between;padding:0 24px;height:56px;background:var(--panel);border-bottom:1px solid var(--border);flex-shrink:0;transition:background .3s,border-color .3s;}
-.logo{font-family:var(--sans);font-weight:800;font-size:20px;color:var(--txthi);user-select:none;transition:color .3s;letter-spacing:.02em;}
-.logo .a{color:var(--cyan);}
-.logo-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-left:10px;font-weight:400;}
+.logo{font-family:'Josefin Sans',sans-serif;font-weight:300;font-size:22px;color:var(--copper);user-select:none;transition:color .3s;letter-spacing:.32em;text-transform:uppercase;}
+.logo-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-left:12px;font-weight:400;}
 .hdr-r{display:flex;align-items:center;gap:18px;}
 .infra{display:flex;gap:14px;}
 .ii{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:12px;color:var(--txtlo);transition:color .3s;}
@@ -54,14 +55,14 @@ header{position:relative;z-index:20;display:flex;align-items:center;justify-cont
 .theme-btn{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--txtlo);cursor:pointer;padding-left:16px;border-left:1px solid var(--border);user-select:none;transition:color .2s,border-color .3s;}
 .theme-btn:hover{color:var(--txt);}
 .trk{width:36px;height:20px;border-radius:10px;background:var(--border);border:1px solid var(--borderhi);position:relative;transition:all .3s;flex-shrink:0;}
-body:not(.light) .trk{background:var(--cyan);border-color:var(--cyan);}
+body:not(.light) .trk{background:var(--accent);border-color:var(--accent);}
 .thmb{width:14px;height:14px;border-radius:50%;background:#fff;position:absolute;top:2px;left:2px;transition:transform .3s,background .3s;box-shadow:0 1px 3px rgba(0,0,0,.2);}
 body:not(.light) .thmb{transform:translateX(16px);}
 
 /* NAV TABS — inline in header */
 .tnav-tab{padding:0 4px;height:56px;display:inline-flex;align-items:center;font-family:var(--sans);font-size:14px;font-weight:600;color:var(--txtlo);cursor:pointer;border-bottom:2px solid transparent;transition:color .15s,border-color .15s;margin:0 8px;}
 .tnav-tab:hover{color:var(--txt);}
-.tnav-tab.active{color:var(--cyan);border-bottom-color:var(--cyan);}
+.tnav-tab.active{color:var(--accent);border-bottom-color:var(--accent);}
 
 /* PAGES */
 .page{display:none;flex:1;min-height:0;flex-direction:column;}
@@ -77,7 +78,7 @@ body:not(.light) .thmb{transform:translateX(16px);}
 /* STATION CARDS */
 .stn-card{flex:1;padding:18px 22px;border-right:1px solid var(--border);background:var(--panel);transition:background .2s,border-color .2s;position:relative;}
 .stn-card:last-child{border-right:none;}
-.stn-card.active-stn{background:var(--raised);border-top:3px solid var(--cyan);}
+.stn-card.active-stn{background:var(--raised);border-top:3px solid var(--accent);}
 .stn-card-name{font-family:var(--sans);font-size:15px;font-weight:700;color:var(--txthi);margin-bottom:2px;}
 .stn-card-sub{font-family:var(--sans);font-size:12px;color:var(--txtlo);margin-bottom:12px;}
 .stn-card-bar{height:10px;background:var(--border);border-radius:5px;overflow:hidden;margin-bottom:8px;}
@@ -95,9 +96,9 @@ body:not(.light) .thmb{transform:translateX(16px);}
 ::-webkit-scrollbar{width:4px;}::-webkit-scrollbar-thumb{background:var(--borderhi);border-radius:2px;}
 .log-item{padding:7px 20px;border-left:3px solid transparent;cursor:pointer;transition:background .12s;display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--divclr);}
 .log-item:hover{background:var(--logbg);}
-.log-item.lit{background:var(--loglit);border-left-color:var(--cyan);}
+.log-item.lit{background:var(--loglit);border-left-color:var(--accent);}
 .log-item.fresh{animation:flash .5s ease-out;}
-@keyframes flash{0%{background:rgba(0,120,180,.18)}100%{background:transparent}}
+@keyframes flash{0%{background:rgba(212,135,94,.18)}100%{background:transparent}}
 .log-ts{font-family:var(--mono);font-size:11px;color:var(--txtlo);white-space:nowrap;flex-shrink:0;}
 .log-row{display:flex;align-items:center;gap:7px;flex:1;min-width:0;}
 .log-name{font-family:var(--sans);font-size:13px;font-weight:600;color:var(--txthi);white-space:nowrap;}
@@ -105,42 +106,42 @@ body:not(.light) .thmb{transform:translateX(16px);}
 .log-corr{display:none;}
 .log-div{display:none;}
 .svc{font-family:var(--sans);font-size:10px;padding:2px 7px;border-radius:3px;flex-shrink:0;font-weight:600;}
-.sf{background:rgba(0,120,180,.12);color:#005fa8;}
+.sf{background:rgba(176,102,74,.12);color:#8b5a3a;}
 .sc{background:rgba(124,58,237,.12);color:#5b21b6;}
 .sn{background:rgba(0,168,107,.12);color:#00694a;}
 .ss{background:rgba(212,130,10,.12);color:#92570a;}
 .su{background:rgba(212,46,85,.12);color:#991b3d;}
-body:not(.light) .sf{background:rgba(0,180,255,.12);color:var(--cyan);}
+body:not(.light) .sf{background:rgba(212,135,94,.12);color:var(--accent);}
 body:not(.light) .sc{background:rgba(167,139,250,.14);color:var(--purple);}
 body:not(.light) .sn{background:rgba(0,229,138,.11);color:var(--green);}
 body:not(.light) .ss{background:rgba(245,166,35,.12);color:var(--amber);}
 body:not(.light) .su{background:rgba(255,64,105,.11);color:var(--red);}
 .sb-footer{padding:8px 20px;border-top:1px solid var(--border);font-family:var(--sans);font-size:12px;color:var(--txtlo);background:var(--panel);}
-.sb-footer a{color:var(--cyan);cursor:pointer;text-decoration:underline;text-underline-offset:2px;}
+.sb-footer a{color:var(--accent);cursor:pointer;text-decoration:underline;text-underline-offset:2px;}
 
 /* POPUP */
 .cmd-popup{display:none;position:absolute;z-index:50;background:var(--panel);border:1px solid var(--borderhi);padding:16px 18px;min-width:240px;box-shadow:0 8px 32px var(--shadow);border-radius:4px;transition:background .3s,border-color .3s;}
-.cmd-popup::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--cyan),transparent);border-radius:4px 4px 0 0;}
+.cmd-popup::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--accent),transparent);border-radius:4px 4px 0 0;}
 .popup-ship{font-family:var(--sans);font-size:16px;font-weight:700;color:var(--txthi);margin-bottom:3px;}
 .popup-stat{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:12px;}
-.popup-hint{font-family:var(--mono);font-size:11px;color:var(--cyandim);margin-bottom:8px;}
+.popup-hint{font-family:var(--mono);font-size:11px;color:var(--accentdim);margin-bottom:8px;}
 .dest-list{display:flex;flex-direction:column;gap:5px;}
 .dest-btn{display:flex;align-items:center;justify-content:space-between;padding:9px 12px;border:1px solid var(--border);border-radius:3px;background:transparent;cursor:pointer;font-family:var(--mono);font-size:11px;color:var(--txt);text-align:left;transition:all .15s;}
-.dest-btn:hover{background:rgba(0,120,180,.06);border-color:var(--borderhi);color:var(--txthi);}
-.dest-btn .arr{color:var(--cyandim);font-size:14px;}
+.dest-btn:hover{background:rgba(212,135,94,.06);border-color:var(--borderhi);color:var(--txthi);}
+.dest-btn .arr{color:var(--accentdim);font-size:14px;}
 .dest-btn.cur{opacity:.4;cursor:not-allowed;}
 .dest-btn.cur:hover{background:transparent;border-color:var(--border);color:var(--txt);}
 .popup-info{margin-top:12px;padding-top:12px;border-top:1px solid var(--border);}
 .pi-row{display:flex;justify-content:space-between;font-family:var(--mono);font-size:12px;padding:3px 0;}
 .pi-k{color:var(--txtlo);}
 .pi-v{color:var(--txthi);}
-.pi-v.c{color:var(--cyan);}
+.pi-v.c{color:var(--accent);}
 .pi-v.a{color:var(--amber);}
 .pi-v.g{color:var(--green);}
 .snap-wrap{margin-top:8px;}
 .snap-lbl{display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:5px;}
 .snap-track{height:4px;background:var(--border);border-radius:2px;position:relative;overflow:visible;}
-.snap-fill{height:100%;background:var(--cyan);border-radius:2px;transition:width .4s;}
+.snap-fill{height:100%;background:var(--accent);border-radius:2px;transition:width .4s;}
 .snap-mark{position:absolute;left:0;top:-4px;width:1px;height:12px;background:var(--amber);opacity:.7;}
 
 /* OVERSIGHT STRIP */
@@ -158,6 +159,23 @@ body:not(.light) .os-strip{background:rgba(7,15,28,.92);}
 .os-req .lb{color:var(--txtlo);}
 .os-req.met .lb{color:var(--txthi);}
 
+/* EVENT LOG PANEL (inline, pushes map) */
+.live-content{display:flex;flex:1;min-height:0;overflow:hidden;}
+.live-main{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0;transition:flex .3s cubic-bezier(.4,0,.2,1);}
+.log-panel{width:0;overflow:hidden;background:var(--panel);border-left:1px solid transparent;display:flex;flex-direction:column;flex-shrink:0;transition:width .3s cubic-bezier(.4,0,.2,1),border-color .3s;}
+.log-panel.open{width:380px;border-left-color:var(--border);}
+.log-panel-hdr{display:flex;align-items:center;justify-content:space-between;padding:14px 20px;border-bottom:1px solid var(--border);flex-shrink:0;min-width:380px;}
+.log-panel-hdr .bar-lbl{font-size:14px;font-weight:700;}
+.log-panel-close{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11px;color:var(--txtlo);cursor:pointer;padding:5px 10px;border:1px solid var(--border);border-radius:3px;transition:all .15s;background:transparent;}
+.log-panel-close:hover{border-color:var(--borderhi);color:var(--txt);}
+.log-panel .log-body{flex:1;max-height:none !important;overflow-y:auto;min-width:380px;}
+.log-panel .sb-footer{margin-top:auto;min-width:380px;}
+.log-toggle{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--txtlo);cursor:pointer;padding:5px 14px;border:1px solid var(--border);border-radius:3px;transition:all .15s;background:transparent;user-select:none;}
+.log-toggle:hover{border-color:var(--borderhi);color:var(--txt);}
+.log-toggle.active{border-color:var(--accent);color:var(--accent);}
+.log-toggle .dot{width:6px;height:6px;}
+.log-count{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;border-radius:9px;background:rgba(212,135,94,.15);color:var(--accent);font-family:var(--mono);font-size:10px;font-weight:600;padding:0 5px;}
+
 /* TOAST */
 .toast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:var(--raised);border:1px solid var(--borderhi);padding:10px 20px;font-family:var(--mono);font-size:12px;color:var(--txthi);z-index:300;white-space:nowrap;animation:tin .25s ease;pointer-events:none;border-radius:4px;}
 @keyframes tin{from{opacity:0;transform:translateX(-50%) translateY(8px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
@@ -170,20 +188,20 @@ body:not(.light) .os-strip{background:rgba(7,15,28,.92);}
 
 .sc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:18px;padding:28px 40px;}
 .sc-card{background:var(--panel);border:1px solid var(--border);padding:22px 24px;cursor:pointer;transition:border-color .2s,background .2s,box-shadow .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--cyan),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
+.sc-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--accent),transparent);opacity:0;transition:opacity .2s;border-radius:4px 4px 0 0;}
 .sc-card:hover{border-color:var(--borderhi);box-shadow:0 4px 20px var(--shadow);}
 .sc-card:hover::before{opacity:1;}
-.sc-card.active{border-color:var(--cyan);background:var(--raised);}
+.sc-card.active{border-color:var(--accent);background:var(--raised);}
 .sc-card.active::before{opacity:1;}
 .sc-num{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-bottom:8px;}
 .sc-name{font-family:var(--sans);font-size:18px;font-weight:700;color:var(--txthi);margin-bottom:6px;}
-.sc-ship{font-family:var(--mono);font-size:12px;color:var(--cyan);margin-bottom:10px;}
+.sc-ship{font-family:var(--mono);font-size:12px;color:var(--accent);margin-bottom:10px;}
 .sc-desc{font-family:var(--sans);font-size:13px;color:var(--txt);line-height:1.6;margin-bottom:12px;}
 .sc-tags{display:flex;flex-wrap:wrap;gap:6px;}
 .sc-tag{font-family:var(--mono);font-size:10px;padding:3px 9px;border-radius:3px;background:var(--raised);color:var(--txtlo);border:1px solid var(--border);}
 body.light .sc-tag{background:var(--bg);}
-.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--cyan);cursor:pointer;transition:all .2s;border-radius:3px;}
-.sc-launch:hover{background:rgba(0,120,180,.08);}
+.sc-launch{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:12px;padding:7px 16px;border:1px solid var(--borderhi);color:var(--accent);cursor:pointer;transition:all .2s;border-radius:3px;}
+.sc-launch:hover{background:rgba(212,135,94,.08);}
 
 /* SCENARIO RUNNER */
 .sc-runner{display:none;position:fixed;inset:0;z-index:100;background:rgba(7,15,28,.97);flex-direction:column;overflow:hidden;}
@@ -203,11 +221,11 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .step{display:flex;align-items:center;gap:0;}
 .step-dot{width:28px;height:28px;border-radius:50%;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:11px;color:var(--txtlo);flex-shrink:0;transition:all .3s;}
 .step.done .step-dot{background:var(--green);border-color:var(--green);color:#fff;}
-.step.active .step-dot{background:var(--cyan);border-color:var(--cyan);color:#fff;box-shadow:0 0 10px var(--cyandim);}
+.step.active .step-dot{background:var(--accent);border-color:var(--accent);color:#fff;box-shadow:0 0 10px var(--accentdim);}
 .step-line{width:28px;height:1px;background:var(--border);flex-shrink:0;}
 .step.done .step-line{background:var(--green);}
 .step-lbl{font-family:var(--mono);font-size:11px;color:var(--txtlo);margin-left:8px;white-space:nowrap;}
-.step.active .step-lbl{color:var(--cyan);}
+.step.active .step-lbl{color:var(--accent);}
 .step.done  .step-lbl{color:var(--greendim);}
 .step-gap{width:16px;flex-shrink:0;}
 
@@ -216,9 +234,9 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .sc-narr-title{font-family:var(--sans);font-size:16px;font-weight:700;color:var(--txthi);margin-bottom:8px;}
 .sc-narr-body{font-family:var(--sans);font-size:14px;color:var(--txt);line-height:1.65;max-width:620px;}
 .sc-action-area{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:28px;gap:18px;}
-.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--cyan);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
-.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--cyan);}
-.sc-big-btn:hover{background:rgba(0,120,180,.08);box-shadow:0 0 20px rgba(0,120,180,.15);}
+.sc-big-btn{font-family:var(--sans);font-size:15px;font-weight:700;padding:14px 36px;border:1px solid var(--borderhi);background:transparent;color:var(--accent);cursor:pointer;transition:all .2s;position:relative;overflow:hidden;border-radius:4px;}
+.sc-big-btn::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--accent);}
+.sc-big-btn:hover{background:rgba(212,135,94,.08);box-shadow:0 0 20px rgba(212,135,94,.15);}
 .sc-big-btn:disabled{opacity:.4;cursor:not-allowed;}
 .sc-sub-btn{font-family:var(--mono);font-size:12px;padding:9px 22px;border:1px solid var(--border);background:transparent;color:var(--txt);cursor:pointer;transition:all .2s;border-radius:3px;}
 .sc-sub-btn:hover{border-color:var(--borderhi);color:var(--txthi);}
@@ -239,10 +257,10 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 
 /* event counter (hydration viz) */
 .hydrate-viz{width:100%;max-width:400px;text-align:center;}
-.hv-counter{font-family:var(--mono);font-size:48px;color:var(--cyan);line-height:1;margin-bottom:8px;transition:color .3s;}
+.hv-counter{font-family:var(--mono);font-size:48px;color:var(--accent);line-height:1;margin-bottom:8px;transition:color .3s;}
 .hv-label{font-family:var(--mono);font-size:12px;color:var(--txtlo);margin-bottom:16px;}
 .hv-bar{height:5px;background:var(--border);border-radius:3px;overflow:hidden;margin-bottom:10px;}
-.hv-fill{height:100%;background:var(--cyan);transition:width .05s linear;}
+.hv-fill{height:100%;background:var(--accent);transition:width .05s linear;}
 .hv-status{font-family:var(--mono);font-size:12px;color:var(--txtlo);}
 
 /* oversight scenario viz */
@@ -276,7 +294,7 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 .cargo-val{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--txthi);}
 .cargo-btns{display:flex;gap:6px;}
 .cargo-btn{font-family:var(--mono);font-size:12px;padding:6px 14px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--txt);cursor:pointer;transition:all .15s;}
-.cargo-btn:hover:not(:disabled){border-color:var(--borderhi);background:rgba(0,120,180,.06);color:var(--txthi);}
+.cargo-btn:hover:not(:disabled){border-color:var(--borderhi);background:rgba(212,135,94,.06);color:var(--txthi);}
 .cargo-btn:disabled{opacity:.35;cursor:not-allowed;}
 .cargo-btn.load{border-color:var(--green);color:var(--green);}
 .cargo-btn.load:hover:not(:disabled){background:rgba(0,168,107,.08);}
@@ -292,7 +310,7 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 <header>
   <div style="display:flex;align-items:center;gap:0;">
     <div style="display:flex;align-items:baseline;margin-right:32px;">
-      <div class="logo">C<span class="a">A</span>NON</div>
+      <div class="logo">Canon</div>
       <div class="logo-sub">/ fleet ops demo</div>
     </div>
     <div class="tnav-tab active" onclick="showPage('live',this)">Live Fleet</div>
@@ -309,38 +327,50 @@ body.light .sc-runner{background:rgba(238,243,249,.98);}
 
 <!-- ═══ LIVE PAGE ═══ -->
 <div class="page live-page active" id="page-live">
-  <div class="map-wrap">
-    <div class="map-bar">
-      <div class="bar-lbl">VSS Meridian</div>
-      <div id="destBar" style="display:flex;gap:8px;align-items:center;"></div>
-    </div>
-    <div class="map-canvas" id="mapCanvas">
-      <canvas id="mapCv" style="position:absolute;inset:0;width:100%;height:100%;"></canvas>
-      <div class="cmd-popup" id="popup">
-        <div class="popup-ship" id="popupName"></div>
-        <div class="popup-stat" id="popupStat"></div>
-        <div class="popup-hint">Select destination:</div>
-        <div class="dest-list" id="destList"></div>
-        <div class="popup-info" id="popupInfo"></div>
-      </div>
-      <div class="os-strip" id="osStrip" style="display:none;">
-        <div class="os-hdr">
-          <div class="os-title" id="osTitle"></div>
-          <div class="os-badge os-nr" id="osBadge">Not Ready</div>
+  <div class="live-content">
+    <div class="live-main">
+      <div class="map-wrap">
+        <div class="map-bar">
+          <div class="bar-lbl">VSS Meridian</div>
+          <button class="log-toggle" id="logToggleBtn" onclick="toggleLogDrawer()">
+            <div class="dot"></div>Event Log <span class="log-count" id="logCount">0</span>
+          </button>
         </div>
-        <div class="os-reqs" id="osReqs"></div>
+        <div class="map-canvas" id="mapCanvas">
+          <canvas id="mapCv" style="position:absolute;inset:0;width:100%;height:100%;"></canvas>
+          <div class="cmd-popup" id="popup">
+            <div class="popup-ship" id="popupName"></div>
+            <div class="popup-stat" id="popupStat"></div>
+            <div class="popup-hint">Select destination:</div>
+            <div class="dest-list" id="destList"></div>
+            <div class="popup-info" id="popupInfo"></div>
+          </div>
+          <div class="os-strip" id="osStrip" style="display:none;">
+            <div class="os-hdr">
+              <div class="os-title" id="osTitle"></div>
+              <div class="os-badge os-nr" id="osBadge">Not Ready</div>
+            </div>
+            <div class="os-reqs" id="osReqs"></div>
+          </div>
+        </div>
+        <!-- STATION CARDS -->
+        <div id="stationCards" style="display:flex;gap:0;border-top:1px solid var(--border);flex-shrink:0;"></div>
+        <!-- SHIP ACTION BAR -->
+        <div id="shipPanel" style="padding:12px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;display:flex;align-items:center;gap:16px;"></div>
       </div>
     </div>
-    <!-- STATION CARDS -->
-    <div id="stationCards" style="display:flex;gap:0;border-top:1px solid var(--border);flex-shrink:0;"></div>
-    <!-- SHIP ACTION BAR -->
-    <div id="shipPanel" style="padding:12px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;display:flex;align-items:center;gap:16px;"></div>
-    <!-- EVENT LOG STRIP -->
-    <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 20px;border-top:1px solid var(--border);background:var(--panel);flex-shrink:0;">
-      <span class="bar-lbl">Event log</span>
-      <div class="live-badge"><div class="dot"></div>Live</div>
+    <!-- EVENT LOG PANEL (inline) -->
+    <div class="log-panel" id="logDrawer">
+      <div class="log-panel-hdr">
+        <div style="display:flex;align-items:center;gap:10px;">
+          <span class="bar-lbl">Event Log</span>
+          <div class="live-badge"><div class="dot"></div>Live</div>
+        </div>
+        <button class="log-panel-close" onclick="toggleLogDrawer()">✕ Close</button>
+      </div>
+      <div class="log-body" id="logBody"></div>
+      <div class="sb-footer">Events are append-only — <a onclick="hlRandom()">highlight random correlation</a></div>
     </div>
-    <div class="log-body" id="logBody" style="max-height:160px;"></div>
   </div>
 </div>
 
@@ -471,6 +501,19 @@ function showToast(msg){
   document.body.appendChild(el);setTimeout(()=>el.remove(),2800);
 }
 
+let logDrawerOpen=false;
+function toggleLogDrawer(){
+  logDrawerOpen=!logDrawerOpen;
+  document.getElementById('logDrawer').classList.toggle('open',logDrawerOpen);
+  document.getElementById('logToggleBtn').classList.toggle('active',logDrawerOpen);
+  // resize canvas after transition so map fills the new space
+  setTimeout(resizeCanvas,320);
+}
+function updateLogCount(){
+  const el=document.getElementById('logCount');
+  if(el)el.textContent=liveLog.length;
+}
+
 // ══════════════════════════════════════════════════════
 // GAME LOGIC
 // ══════════════════════════════════════════════════════
@@ -531,7 +574,7 @@ function renderGamePanel(){
     }
   } else if(ship.cargo>0){
     if(ship.cargoFor===curSt.id){
-      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--cyan);">${curSt.label}</strong></span>`+
+      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--accent);">${curSt.label}</strong></span>`+
         `<button class="cargo-btn unload" style="margin-left:auto;" onclick="unloadCargo()">Deliver supplies here</button>`;
     } else {
       const destSt=STATIONS.find(s=>s.id===ship.cargoFor);
@@ -540,7 +583,7 @@ function renderGamePanel(){
   } else {
     const suppliesFor=STATIONS.find(s=>s.suppliedBy===curSt.id);
     if(suppliesFor){
-      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--cyan);">${curSt.label}</strong></span>`+
+      actionHtml=`<span style="font-size:13px;color:var(--txtlo);">Docked at <strong style="color:var(--accent);">${curSt.label}</strong></span>`+
         `<button class="cargo-btn load" style="margin-left:auto;" onclick="loadCargo()">Load supplies for ${suppliesFor.label}</button>`;
     } else {
       actionHtml='<span style="font-size:13px;color:var(--txtlo);">Nothing to load at this station</span>';
@@ -622,6 +665,7 @@ function renderLog(){
     </div>`;
   }).join('');
   liveLog.forEach(e=>e.fresh=false);
+  updateLogCount();
 }
 function selCorr(c){hlCorr=hlCorr===c?null:c;renderLog();}
 function hlRandom(){const e=liveLog[Math.floor(Math.random()*liveLog.length)];if(e)selCorr(e.corr);}
@@ -716,11 +760,11 @@ function drawMap(){
   ctx.clearRect(0,0,W,H);
 
   // background follows theme
-  ctx.fillStyle=lightMode?'#eef3f9':'#070f1c';
+  ctx.fillStyle=lightMode?'#f5f0eb':'#0f0d0b';
   ctx.fillRect(0,0,W,H);
 
   // grid
-  ctx.strokeStyle=lightMode?'rgba(0,120,180,.06)':'rgba(0,160,230,.04)';
+  ctx.strokeStyle=lightMode?'rgba(212,135,94,.06)':'rgba(212,135,94,.04)';
   ctx.lineWidth=1;
   for(let x=0;x<W;x+=70){ctx.beginPath();ctx.moveTo(x,0);ctx.lineTo(x,H);ctx.stroke();}
   for(let y=0;y<H;y+=70){ctx.beginPath();ctx.moveTo(0,y);ctx.lineTo(W,y);ctx.stroke();}
@@ -746,7 +790,7 @@ function drawMap(){
     const to=stationXY(dest);
     ctx.save();
     ctx.setLineDash([5,8]);
-    ctx.strokeStyle=lightMode?'rgba(0,120,180,.25)':'rgba(0,160,230,.22)';
+    ctx.strokeStyle=lightMode?'rgba(212,135,94,.25)':'rgba(212,135,94,.22)';
     ctx.lineWidth=1;
     ctx.beginPath();ctx.moveTo(from.x,from.y);ctx.lineTo(to.x,to.y);ctx.stroke();
     ctx.restore();
@@ -789,7 +833,7 @@ function drawMap(){
     // label
     ctx.font=`600 13px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'rgba(10,30,60,0.75)':'rgba(200,220,240,0.85)';
+    ctx.fillStyle=lightMode?'rgba(42,30,20,0.75)':'rgba(224,210,196,0.85)';
     ctx.fillText(st.label,x,y+r+18);
     // stock indicator
     const pct=Math.round(st.stock);
@@ -821,29 +865,29 @@ function drawMap(){
     ctx.beginPath();ctx.moveTo(-4,9);ctx.lineTo(4,9);ctx.lineTo(0,17+Math.sin(mapTick*0.35)*3);ctx.closePath();ctx.fill();
     ctx.globalAlpha=1;
     // hull
-    ctx.fillStyle='#4a90d9';
+    ctx.fillStyle='#c47a52';
     ctx.beginPath();ctx.moveTo(0,-14);ctx.lineTo(8,9);ctx.lineTo(0,5);ctx.lineTo(-8,9);ctx.closePath();ctx.fill();
     // cockpit
     ctx.fillStyle='#fff';ctx.beginPath();ctx.arc(0,-5,4,0,Math.PI*2);ctx.fill();
     ctx.restore();
     ctx.font=`600 12px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'#1a5fa8':'#85b7eb';
+    ctx.fillStyle=lightMode?'#8b5a3a':'#d4975e';
     ctx.fillText('VSS MERIDIAN',spx,spy+26);
   } else {
     // docked ship — draw on planet or at center
     ctx.save();ctx.translate(spx,spy);
-    ctx.fillStyle='#4a90d9';
+    ctx.fillStyle='#c47a52';
     ctx.beginPath();ctx.moveTo(0,-14);ctx.lineTo(8,9);ctx.lineTo(0,5);ctx.lineTo(-8,9);ctx.closePath();ctx.fill();
     ctx.fillStyle='#fff';ctx.beginPath();ctx.arc(0,-5,4,0,Math.PI*2);ctx.fill();
     ctx.restore();
     ctx.font=`600 12px Inter, sans-serif`;
     ctx.textAlign='center';
-    ctx.fillStyle=lightMode?'#1a5fa8':'#85b7eb';
+    ctx.fillStyle=lightMode?'#8b5a3a':'#d4975e';
     ctx.fillText('VSS MERIDIAN',spx,spy+26);
     if(!meridian.stationId){
       ctx.font=`13px Inter, sans-serif`;
-      ctx.fillStyle=lightMode?'rgba(30,80,150,0.5)':'rgba(150,200,255,0.5)';
+      ctx.fillStyle=lightMode?'rgba(140,90,60,0.5)':'rgba(212,151,94,0.5)';
       ctx.fillText('click a planet to fly there',spx,spy+44);
     }
   }
@@ -851,22 +895,7 @@ function drawMap(){
 
 function renderMap(){drawMap();}  // kept for compat calls
 
-function updateDestBar(){
-  const ship=ships[0];
-  const bar=document.getElementById('destBar');
-  if(!bar)return;
-  if(ship.status==='transit'){
-    const dest=STATIONS.find(s=>s.id===ship.dest);
-    const cargoStr=ship.cargo>0?` · ${ship.cargo}t cargo`:'';
-    bar.innerHTML=`<span style="font-family:var(--mono);font-size:12px;color:var(--cyan);">▶ En route → ${dest?.label||'?'}${cargoStr}</span>`;
-    return;
-  }
-  bar.innerHTML=STATIONS.map(st=>{
-    const here=st.id===ship.stationId;
-    return`<button class="pill ${here?'pg':'pc'}" style="cursor:${here?'default':'pointer'};border:none;font-family:var(--mono);font-size:11px;padding:4px 12px;"
-      ${here?'':'onclick="userDepart(\''+st.id+'\')"'}>${here?'◉ '+st.label:st.label}</button>`;
-  }).join('');
-}
+function updateDestBar(){}
 
 function userDepart(destId){
   const ship=ships[0];
@@ -908,7 +937,7 @@ function onShipClick(e,id){
     <div class="pi-row"><span class="pi-k">Fuel</span><span class="pi-v a">${ship.fuel}%</span></div>
     <div class="pi-row"><span class="pi-k">Version</span><span class="pi-v c">v.${ship.ver}</span></div>
     <div class="snap-wrap">
-      <div class="snap-lbl"><span>Events since snapshot</span><span style="color:var(--cyandim)">${since}/50</span></div>
+      <div class="snap-lbl"><span>Events since snapshot</span><span style="color:var(--accentdim)">${since}/50</span></div>
       <div class="snap-track"><div class="snap-mark"></div><div class="snap-fill" style="width:${Math.min(100,since/50*100)}%"></div></div>
     </div>`;
 }


### PR DESCRIPTION
## Summary
Restyles the frontend from blue/cyan to warm copper/brown and fixes station stock reactivity so cards update the instant each StockDrained event arrives.

### Theme
- Colour palette: `--cyan` → `--accent` (`#d4875e` copper), all CSS vars updated
- Logo: Josefin Sans 300 weight, letter-spaced uppercase
- Event log: inline sliding side panel with toggle button (replaces bottom strip)
- Page routing: CSS display toggle (keeps LiveFleetPage mounted for reactivity)

### Stock drain
- Gateway drain task: random 1-5% of capacity per 3s tick
- Station-service `CargoReceived` combiner: clamp stock to `capacity_kg`
- Frontend: synchronous DOM updates in WS handler (bypasses Leptos 0.7 issue where view closures don't re-render from JS callbacks)
- Display stock with 1 decimal place so every drain event is visible
- Clamp display to 0-100%, sort hydrated stations to canonical order

### Other
- Timestamps: `HH:MM:SS.mmm` instead of full ISO
- Canvas: `--cyan` field renamed to `--accent` with copper defaults

## Test plan
- [x] `cargo check -p frontend` passes
- [x] Playwright stock drain test: cards update immediately when StockDrained arrives
- [x] Stock never exceeds 100%
- [x] Station order stable after hydration (Alpha, Beta, Gamma, Delta)
- [x] Event log populates with real pipeline events
- [x] Copper theme matches updated mockup.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)