### PR TITLE
feat(demo): eliminate shared domain types — each service owns its domain (#309)

### DIFF
--- a/canon-demo/cargo-service/src/event_handlers.rs
+++ b/canon-demo/cargo-service/src/event_handlers.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use canon_core::{AggregateId, CommandEnvelope, EventEnvelope, IncomingMessage, Oversight};
+use canon_core::{AggregateId, CommandEnvelope, IncomingMessage, Oversight};
 use uuid::Uuid;
 
 use crate::events::CargoEvent;
@@ -88,34 +88,30 @@ impl UnloadingHandler {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Helper: construct an EventEnvelope for testing
-// ---------------------------------------------------------------------------
-
-/// Build a minimal `EventEnvelope` for use in tests and handler logic.
-pub fn make_event_envelope(
-    event_type: &str,
-    event_version: u32,
-    aggregate_id: Uuid,
-    payload: Bytes,
-) -> EventEnvelope {
-    EventEnvelope {
-        event_id: Uuid::new_v4(),
-        aggregate_id: AggregateId::from_uuid(aggregate_id),
-        version: canon_core::Version::initial(),
-        event_type: event_type.to_string(),
-        event_version,
-        payload,
-        correlation_id: Uuid::new_v4(),
-        causation_id: Uuid::new_v4(),
-        timestamp: chrono::Utc::now(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use canon_core::EventHandler;
+    use canon_core::{EventEnvelope, EventHandler};
+
+    /// Build a minimal `EventEnvelope` for use in tests.
+    fn make_event_envelope(
+        event_type: &str,
+        event_version: u32,
+        aggregate_id: Uuid,
+        payload: Bytes,
+    ) -> EventEnvelope {
+        EventEnvelope {
+            event_id: Uuid::new_v4(),
+            aggregate_id: AggregateId::from_uuid(aggregate_id),
+            version: canon_core::Version::initial(),
+            event_type: event_type.to_string(),
+            event_version,
+            payload,
+            correlation_id: Uuid::new_v4(),
+            causation_id: Uuid::new_v4(),
+            timestamp: chrono::Utc::now(),
+        }
+    }
 
     fn external_event(event_type: &str) -> IncomingMessage {
         IncomingMessage::ExternalEvent(make_event_envelope(


### PR DESCRIPTION
## Summary

- Move all command/event types from `canon-demo-shared` into owning services
- Each service now uses Canon's proc-macros exclusively — zero manual trait impls
- Cross-service events consumed via anti-corruption layer types (local inbound structs)
- Shared crate stripped to infrastructure only (db, offsets, topics)
- Navigation service rewritten from fully manual to fully macro-driven (~500 lines eliminated)
- Cargo service manual combiners replaced with `#[event_combiner]` macros (~200 lines eliminated)
- Fleet projection rewritten with `#[projection]` + `#[projection_handler]` macros
- canon-test updated to import from service crates
- Frontend stale shared dependency removed

**47 files changed, +1214 / -2127 lines (net -913)**

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — all unit + tier1 tests pass (tier2 ScyllaDB container timeouts are pre-existing infra issue)
- [x] No `canon_demo_shared::commands` or `canon_demo_shared::events` imports remain
- [x] Every service uses proc-macros for all domain types
- [ ] `make k8s-up` + `make k8s-test-e2e` (Playwright smoke tests)

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)