### PR TITLE
docs: update CLAUDE.md for rskafka migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,23 @@ events from the outbound queue.
 
 All consumers restart from offset 0 and rely on downstream idempotency to skip already-processed events. No Kafka-side offset commit.
 
+### Kafka crate patterns (rskafka)
+
+All four Kafka crates (`canon-inbound-queue-kafka`, `canon-outbound-queue-kafka`,
+`canon-publisher-kafka`, `canon-adaptor-kafka`) use `rskafka` with a consistent pattern:
+
+- **Connection**: `ClientBuilder::new(broker_list).build().await` then
+  `client.partition_client(topic, 0, UnknownTopicHandling::Retry)` to get a `PartitionClient`.
+- **Produce**: `partition_client.produce(vec![record], Compression::NoCompression)` with
+  `Record { key, value, headers: BTreeMap::new(), timestamp }`.
+- **Consume**: `partition_client.fetch_records(next_offset, 1..1_048_576, timeout_ms)` in a
+  polling loop. Offset tracked in-memory (`Mutex<i64>`, starts at 0).
+- **Commit**: Always a no-op. Application-layer idempotency (inbox dedup, Cassandra PK,
+  projection checkpoint) handles duplicates on restart.
+- **No consumer groups**: rskafka has no consumer group abstraction. Each consumer polls
+  partition 0 independently. `group_id` fields are kept for API compatibility but unused.
+- **Errors**: each crate defines its own `thiserror` error type wrapping rskafka errors as strings.
+
 ### Inbox
 - Idempotent intake via `handler_id + message_id` composite key
 - Window key is `(handler_id, correlation_key)` — from handler's `correlate` fn or fallback to envelope `correlation_id`


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to reflect the rskafka migration -- closes #291.

## What changed

Most rskafka documentation was already in place (non-negotiable rules, offset management,
deployment cross-compilation, banned deps list). The one missing piece was a reference
guide for the rskafka `PartitionClient` patterns used consistently across all four Kafka
crates.

**Added:**
- New "Kafka crate patterns (rskafka)" subsection in Operational Details, documenting:
  - Connection pattern (`ClientBuilder` + `partition_client`)
  - Produce pattern (`PartitionClient::produce` with `Record`)
  - Consume pattern (`fetch_records` polling loop with in-memory offset)
  - Commit no-op (application-layer idempotency)
  - No consumer groups (rskafka limitation, `group_id` kept for API compat)
  - Error handling pattern (per-crate `thiserror` types)

**Already present (verified, no changes needed):**
- Non-negotiable rules: rskafka-only policy (line 51)
- Operational details: restart-from-zero offset management (line 311)
- Deployment: cross-compilation instructions, no Docker Rust builds (lines 370-387)
- What never to do: rdkafka/cmake-build/librdkafka-sys banned (line 665), external offset storage banned (line 666)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)