### PR TITLE
feat(k8s): NetworkPolicy for GKE infra isolation

### DIFF
--- a/canon-demo/k8s/overlays/gke/infra-policies/kustomization.yaml
+++ b/canon-demo/k8s/overlays/gke/infra-policies/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: canon-infra
+
+resources:
+  - network-policies.yaml

--- a/canon-demo/k8s/overlays/gke/infra-policies/network-policies.yaml
+++ b/canon-demo/k8s/overlays/gke/infra-policies/network-policies.yaml
@@ -1,0 +1,35 @@
+# NetworkPolicy for canon-infra namespace.
+# Restricts ingress to only canon-prod, canon-staging, and canon-infra namespaces.
+# Requires --enable-network-policy on the GKE cluster.
+
+# Default deny all ingress to canon-infra
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: infra-default-deny
+  namespace: canon-infra
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Allow ingress from canon-prod, canon-staging, and canon-infra only
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: infra-allow-app-namespaces
+  namespace: canon-infra
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - canon-prod
+                  - canon-staging
+                  - canon-infra

--- a/canon-demo/k8s/overlays/gke/prod/gateway-network-policy.yaml
+++ b/canon-demo/k8s/overlays/gke/prod/gateway-network-policy.yaml
@@ -1,0 +1,29 @@
+# NetworkPolicy for the gateway in canon-prod.
+# Allows ingress from GKE Ingress controller, same-namespace pods,
+# and GCE health check IP ranges.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: gateway-allow-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow from GKE Ingress controller (kube-system namespace)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+    # Allow from same namespace
+    - from:
+        - podSelector: {}
+    # Allow GCE health check ranges
+    - from:
+        - ipBlock:
+            cidr: 130.211.0.0/22
+    - from:
+        - ipBlock:
+            cidr: 35.191.0.0/16

--- a/canon-demo/k8s/overlays/gke/prod/kustomization.yaml
+++ b/canon-demo/k8s/overlays/gke/prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - managed-cert.yaml
   - frontend-config.yaml
   - backend-config.yaml
+  - gateway-network-policy.yaml
 
 components:
   - ../shared

--- a/canon-demo/k8s/overlays/gke/staging/gateway-network-policy.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/gateway-network-policy.yaml
@@ -1,0 +1,29 @@
+# NetworkPolicy for the gateway in canon-staging.
+# Allows ingress from GKE Ingress controller, same-namespace pods,
+# and GCE health check IP ranges.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: gateway-allow-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow from GKE Ingress controller (kube-system namespace)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+    # Allow from same namespace
+    - from:
+        - podSelector: {}
+    # Allow GCE health check ranges
+    - from:
+        - ipBlock:
+            cidr: 130.211.0.0/22
+    - from:
+        - ipBlock:
+            cidr: 35.191.0.0/16

--- a/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - managed-cert.yaml
   - frontend-config.yaml
   - backend-config.yaml
+  - gateway-network-policy.yaml
 
 components:
   - ../shared


### PR DESCRIPTION
## Summary

Adds NetworkPolicy resources for GKE infra isolation -- closes #314.

- **Default deny + allow-list for `canon-infra` namespace**: only `canon-prod`, `canon-staging`, and `canon-infra` can reach infra pods (YugabyteDB, Cassandra, Kafka)
- **Gateway NetworkPolicy in both app namespaces**: allows GKE Ingress controller health checks + same-namespace traffic
- **GCE health check IP ranges whitelisted**: `130.211.0.0/22`, `35.191.0.0/16`

## Structure

Infra policies live in a standalone kustomization (`k8s/overlays/gke/infra-policies/`) applied separately via `kubectl apply -k`, because the app overlay namespace transformers would override `canon-infra` to `canon-prod`/`canon-staging`. Gateway policies are local resources in each app overlay.

```
gke/
  infra-policies/          # kubectl apply -k (targets canon-infra namespace)
    kustomization.yaml
    network-policies.yaml  # default-deny + allow canon-prod/staging/infra
  prod/
    gateway-network-policy.yaml   # gateway ingress from Ingress controller + GCE health checks
    kustomization.yaml            # updated to include gateway policy
  staging/
    gateway-network-policy.yaml
    kustomization.yaml
```

## Test plan

- [x] `kubectl kustomize` builds cleanly for all three kustomizations (infra-policies, prod, staging)
- [ ] After apply: app pods can reach Kafka, Cassandra, YugabyteDB
- [ ] After apply: external traffic cannot reach infra pods directly
- [ ] Gateway accepts GKE Ingress health checks

🤖 Generated with [Claude Code](https://claude.ai/claude-code)