### PR TITLE
feat(make): GKE Makefile targets and monitoring alerts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           # Backend services (cross-compiled x86_64-musl binaries)
           for svc in fleet-service cargo-service navigation-service supply-service station-service gateway; do
             docker build -t $REGISTRY/$svc:$SHA -t $REGISTRY/$svc:latest \
-              --build-arg BINARY_PATH=target/x86_64-unknown-linux-musl/release/$svc \
+              --build-arg CROSS_TARGET=x86_64-unknown-linux-musl \
               -f canon-demo/$svc/Dockerfile .
             docker push $REGISTRY/$svc:$SHA
             docker push $REGISTRY/$svc:latest

--- a/canon-demo/Makefile
+++ b/canon-demo/Makefile
@@ -162,6 +162,7 @@ k8s-clean: k8s-down ## Full cleanup: delete namespace and stop minikube
 
 GKE_REGISTRY := europe-west2-docker.pkg.dev/canon-demo-prod/canon
 GKE_CROSS_TARGET := x86_64-unknown-linux-musl
+GKE_SHA := $(shell git rev-parse --short HEAD)
 GKE_DEPLOYS := fleet-service cargo-service navigation-service supply-service station-service gateway frontend
 
 .PHONY: gke-build-push
@@ -173,18 +174,27 @@ gke-build-push: ## Cross-compile x86_64, build and push all images to Artifact R
 	@for svc in $(SERVICES); do \
 		echo "    $$svc..."; \
 		docker build --no-cache --build-arg CROSS_TARGET=$(GKE_CROSS_TARGET) \
+			-t $(GKE_REGISTRY)/$$svc:$(GKE_SHA) \
 			-t $(GKE_REGISTRY)/$$svc:latest \
 			-f $$svc/Dockerfile ../.; \
+		docker push $(GKE_REGISTRY)/$$svc:$(GKE_SHA); \
 		docker push $(GKE_REGISTRY)/$$svc:latest; \
 	done
 	@echo "==> Building and pushing frontend image..."
-	docker build --no-cache -t $(GKE_REGISTRY)/frontend:latest \
+	docker build --no-cache \
+		-t $(GKE_REGISTRY)/frontend:$(GKE_SHA) \
+		-t $(GKE_REGISTRY)/frontend:latest \
 		-f frontend/Dockerfile ../.
+	docker push $(GKE_REGISTRY)/frontend:$(GKE_SHA)
 	docker push $(GKE_REGISTRY)/frontend:latest
 	@echo "==> Building and pushing init-schema image..."
-	docker build --no-cache -t $(GKE_REGISTRY)/init-schema:latest init-schema/
+	docker build --no-cache \
+		-t $(GKE_REGISTRY)/init-schema:$(GKE_SHA) \
+		-t $(GKE_REGISTRY)/init-schema:latest \
+		init-schema/
+	docker push $(GKE_REGISTRY)/init-schema:$(GKE_SHA)
 	docker push $(GKE_REGISTRY)/init-schema:latest
-	@echo "==> All images pushed to $(GKE_REGISTRY)."
+	@echo "==> All images pushed to $(GKE_REGISTRY) (SHA: $(GKE_SHA))."
 
 .PHONY: gke-deploy-prod
 gke-deploy-prod: ## Apply prod overlay and wait for rollouts


### PR DESCRIPTION
## Summary

Adds GKE Makefile targets and monitoring setup -- closes #317.

## What's included

- `gke-build-push` -- cross-compile x86_64 + push 8 images to Artifact Registry
- `gke-deploy-prod` / `gke-deploy-staging` / `gke-deploy` -- apply overlays + wait for rollouts
- `gke-status` -- pods, services, ingress across all 3 namespaces
- `gke-logs-prod` / `gke-logs-staging` -- tail app logs
- `gke-restart-prod` / `gke-restart-staging` -- rollout restart
- `gke-monitoring-setup` -- create uptime checks + email alerts via gcloud
- Dockerfiles parameterised with `CROSS_TARGET` build arg (default: aarch64, GKE passes x86_64)
- Fixed `make help` regex to include digits so `k8s-*` targets appear in output

## Test plan

- [x] `make help` shows all targets (both k8s and gke)
- [x] `make --dry-run gke-status` expands correctly for all 3 namespaces
- [x] `make --dry-run gke-build-push` cross-compiles x86_64 and pushes to correct registry
- [x] `make --dry-run gke-deploy` applies both overlays and waits for rollouts
- [x] `make --dry-run gke-monitoring-setup ALERT_EMAIL=test@example.com` creates uptime checks
- [ ] `make gke-build-push` cross-compiles and pushes (requires GKE auth)
- [ ] `make gke-deploy` applies both overlays (requires GKE cluster access)
- [ ] `make gke-monitoring-setup ALERT_EMAIL=...` creates uptime checks (requires gcloud auth)

Generated with [Claude Code](https://claude.ai/claude-code)