### PR TITLE
fix(staging): codify public access and staging image tags

### DIFF
--- a/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
@@ -14,6 +14,15 @@ resources:
 components:
   - ../shared
 
+# Staging should not drift with mutable prod-facing tags.
+images:
+  - name: canon-demo/gateway
+    newName: europe-west2-docker.pkg.dev/canon-demo-prod/canon/gateway
+    newTag: staging
+  - name: canon-demo/frontend
+    newName: europe-west2-docker.pkg.dev/canon-demo-prod/canon/frontend
+    newTag: staging
+
 # Override the base ConfigMap with GKE staging infra endpoints and schemas.
 # Infra lives in the canon-infra namespace; app services connect cross-namespace.
 # Staging uses prefixed schemas and topic names for isolation from prod.
@@ -218,11 +227,6 @@ patches:
                 env:
                   - name: CORS_ORIGIN
                     value: "https://canon-staging.mopjones.com"
-                  - name: CANON_AUTH_PASSWORD
-                    valueFrom:
-                      secretKeyRef:
-                        name: canon-secrets
-                        key: auth-password
                   - name: CANON_DEBUG_KEY
                     valueFrom:
                       secretKeyRef:


### PR DESCRIPTION
## Summary
- remove the staging-only gateway auth env override
- pin staging gateway and frontend manifests to the  tag instead of inheriting mutable 

## Why
- canon-staging had become public at the ingress layer but still returned 401s because the gateway overlay reintroduced 
- canon-staging drifted back to an older frontend bundle because the overlay was still following mutable 

## Testing
- removed auth from the live staging gateway deployment and verified unauthenticated  returns 200
- re-pinned the live staging frontend and verified the corrected bundle is served
- updated the staging overlay so future applies preserve that behavior