### PR TITLE
feat(gateway): add session snapshot bootstrap

### DIFF
--- a/canon-demo/frontend/src/hydrate.rs
+++ b/canon-demo/frontend/src/hydrate.rs
@@ -1,8 +1,7 @@
-//! Fetch initial state from gateway REST endpoints.
+//! Fetch initial state from the gateway snapshot endpoint.
 //!
-//! On mount, attempts to hydrate ships, stations, oversight windows, and dead
-//! letters from the gateway. Falls back silently to demo defaults when the
-//! gateway is unavailable.
+//! On mount, attempts to hydrate the full session snapshot from the gateway.
+//! Falls back silently to demo defaults when the gateway is unavailable.
 
 use leptos::prelude::*;
 use serde::Deserialize;
@@ -50,6 +49,7 @@ struct OversightWindowResponse {
     ship_name: String,
     #[allow(dead_code)]
     dest_label: String,
+    #[allow(dead_code)]
     status: String,
     requirements: Vec<RequirementResponse>,
     #[allow(dead_code)]
@@ -64,280 +64,254 @@ struct RequirementResponse {
     met: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct GameStateResponse {
+    ship: Option<ShipStateResponse>,
+    stations: Vec<StationStateResponse>,
+    cargo: Option<GameCargoResponse>,
+    oversight: Option<OversightWindowResponse>,
+    dead_letters: Vec<DeadLetterEntry>,
+    events: Vec<GameEventResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GameCargoResponse {
+    manifest_id: Uuid,
+    #[allow(dead_code)]
+    voyage_id: Uuid,
+    destination_station_id: Option<Uuid>,
+    amount_pct: u32,
+    #[allow(dead_code)]
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GameEventResponse {
+    id: Uuid,
+    timestamp: String,
+    version: u64,
+    service: String,
+    event_name: String,
+    aggregate_id: Uuid,
+    correlation_id: Uuid,
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 
-/// Fetch initial state from gateway REST endpoints, filtered by session.
-///
-/// Hydrates ships, stations, oversight windows, and dead letters from
-/// the gateway. All requests include `?session_id=` so the gateway
-/// returns only entities belonging to this session.
+/// Fetch initial session state from the gateway snapshot endpoint.
 pub fn hydrate_from_gateway(state: AppState, session_id: Uuid) {
     let base = gateway_base_url();
-    let sid = session_id.to_string();
-
-    // Hydrate stations before ships so that if the ship is already
-    // docked (e.g. page reload), the station_id→position lookup works.
-    // Fresh ships start in the center by design — user chooses where to fly.
-    hydrate_stations_then_ships(state, base.clone(), sid.clone(), base.clone(), sid.clone());
-    hydrate_oversight(state, base.clone(), sid.clone());
-    hydrate_dead_letters(state, base, sid);
-}
-
-// ---------------------------------------------------------------------------
-// Sequential station → ship hydration
-// ---------------------------------------------------------------------------
-
-fn hydrate_stations_then_ships(
-    state: AppState,
-    base_stations: String,
-    sid_stations: String,
-    base_ships: String,
-    sid_ships: String,
-) {
     spawn_local(async move {
-        // Hydrate stations first (blocking) so ship position lookup works.
-        do_hydrate_stations(state, &base_stations, &sid_stations).await;
-        // Now hydrate ships — stations signal is populated.
-        do_hydrate_ships(state, &base_ships, &sid_ships).await;
+        let url = format!("{base}/game/{session_id}");
+        let resp = match gloo_net::http::Request::get(&url).send().await {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        if !resp.ok() {
+            return;
+        }
+
+        let snapshot: GameStateResponse = match resp.json().await {
+            Ok(snapshot) => snapshot,
+            Err(_) => return,
+        };
+
+        apply_snapshot(state, snapshot);
     });
 }
 
 // ---------------------------------------------------------------------------
-// Individual hydration requests
+// Snapshot mapping
 // ---------------------------------------------------------------------------
 
-async fn do_hydrate_ships(state: AppState, base: &str, sid: &str) {
-    {
-        let url = format!("{base}/ships?session_id={sid}");
-        let resp = match gloo_net::http::Request::get(&url).send().await {
-            Ok(r) => r,
-            Err(_) => return, // gateway unavailable -- keep demo defaults
-        };
+fn apply_snapshot(state: AppState, snapshot: GameStateResponse) {
+    let mapped_stations = map_stations(snapshot.stations);
+    let mapped_ship = snapshot
+        .ship
+        .map(|ship| map_ship(ship, &mapped_stations))
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mapped_cargo = snapshot
+        .cargo
+        .and_then(|cargo| map_cargo(cargo, &mapped_stations));
 
-        if !resp.ok() {
-            return;
-        }
-
-        let ships: Vec<ShipStateResponse> = match resp.json().await {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-
-        if ships.is_empty() {
-            return; // no ships registered yet -- keep demo defaults
-        }
-
-        // Station positions for layout (we keep the canonical positions)
-        let station_positions = default_station_positions();
-
-        let mapped: Vec<ShipState> = ships
+    state.stations.set(mapped_stations);
+    state.ships.set(mapped_ship);
+    state.cargo.set(mapped_cargo.clone());
+    state
+        .last_manifest_id
+        .set(mapped_cargo.as_ref().and_then(|cargo| cargo.manifest_id));
+    state.dead_letters.set(snapshot.dead_letters);
+    state.log_entries.set(
+        snapshot
+            .events
             .into_iter()
-            .map(|s| {
-                let status = match s.status.as_str() {
-                    "docked" | "Docked" => ShipStatus::Docked,
-                    "transit" | "Transit" => ShipStatus::Transit,
-                    "dead" | "Dead" => ShipStatus::Dead,
-                    _ => ShipStatus::Docked,
-                };
-
-                // Try to find which station this ship is at so we can position it
-                let station_idx = s.station_id.and_then(|sid| {
-                    state
-                        .stations
-                        .with_untracked(|stations| stations.iter().position(|st| st.id == sid))
-                });
-
-                let (left, top) = station_idx
-                    .and_then(|i| station_positions.get(i))
-                    .copied()
-                    .unwrap_or((48.0, 44.0)); // default to center if unknown
-
-                let snapshot_every = 50u32;
-                let events_since = (s.aggregate_version.saturating_sub(s.last_snapshot_version)
-                    as u32)
-                    % snapshot_every;
-
-                ShipState {
-                    id: s.id,
-                    name: s.name,
-                    status,
-                    fuel_pct: s.fuel_pct as f32,
-                    version: s.aggregate_version,
-                    events_since_snapshot: events_since,
-                    snapshot_every,
-                    current_station_idx: station_idx,
-                    destination_station_idx: None,
-                    left_pct: left,
-                    top_pct: top,
-                    canvas_x: None,
-                    canvas_y: None,
-                    from_pct_x: None,
-                    from_pct_y: None,
-                    flight_start_ms: None,
-                    flight_duration_ms: None,
-                }
+            .map(|event| crate::state::LogEntry {
+                id: event.id,
+                timestamp: event.timestamp,
+                version: event.version,
+                service: event.service,
+                event_name: event.event_name,
+                aggregate_id: event.aggregate_id,
+                correlation_id: event.correlation_id,
+                is_new: false,
             })
-            .collect();
+            .collect(),
+    );
 
-        state.ships.set(mapped);
-    }
-}
-
-async fn do_hydrate_stations(state: AppState, base: &str, sid: &str) {
-    {
-        let url = format!("{base}/stations?session_id={sid}");
-        let resp = match gloo_net::http::Request::get(&url).send().await {
-            Ok(r) => r,
-            Err(_) => return,
-        };
-
-        if !resp.ok() {
-            return;
-        }
-
-        let mut stations: Vec<StationStateResponse> = match resp.json().await {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-
-        if stations.is_empty() {
-            return; // keep demo defaults
-        }
-
-        // Sort to match canonical order: Alpha, Beta, Gamma, Delta.
-        // This ensures positions, planet colours, and supply-chain links
-        // are assigned correctly regardless of API return order.
-        let canonical_order = ["Alpha Depot", "Beta Relay", "Gamma Outpost", "Delta Prime"];
-        stations.sort_by_key(|s| {
-            canonical_order
-                .iter()
-                .position(|&name| name == s.name)
-                .unwrap_or(usize::MAX)
-        });
-
-        // Map gateway stations onto canonical positions.
-        let positions = default_station_positions();
-        // Canvas rendering properties keyed by station index
-        let planet_color_vars = [
-            "--planet-green",
-            "--planet-purple",
-            "--planet-coral",
-            "--planet-blue",
-        ];
-        let planet_radii = [32.0, 22.0, 28.0, 20.0];
-        let has_rings = [false, true, false, false];
-        let supplied_by_names = ["Delta Prime", "Alpha Depot", "Beta Relay", "Gamma Outpost"];
-
-        let mapped: Vec<StationDef> = stations
-            .into_iter()
-            .enumerate()
-            .map(|(i, s)| {
-                let (left, top) = positions.get(i).copied().unwrap_or((50.0, 50.0));
-                // Stock comes from the pipeline — the gateway bootstrap task
-                // seeds initial stock via RecordCargoReceived commands.
-                let stock_pct: f64 = if s.capacity_kg > 0.0 {
-                    (s.current_stock_kg as f64 / s.capacity_kg as f64 * 100.0).clamp(0.0, 100.0)
+    if let Some(window) = snapshot.oversight {
+        let arrival = window
+            .requirements
+            .iter()
+            .find(|r| r.label == "ShipArrivedAtStation")
+            .map(|r| {
+                if r.met {
+                    OversightReqStatus::Met
                 } else {
-                    0.0
-                };
-                let stock_low = stock_pct < STOCK_LOW_THRESHOLD;
-                StationDef {
-                    id: s.id,
-                    name: s.name,
-                    left_pct: left,
-                    top_pct: top,
-                    stock_low,
-                    stock_pct,
-                    planet_color_var: planet_color_vars.get(i).unwrap_or(&"--accent").to_string(),
-                    planet_radius: planet_radii.get(i).copied().unwrap_or(20.0),
-                    has_ring: has_rings.get(i).copied().unwrap_or(false),
-                    capacity_kg: s.capacity_kg as f64,
-                    supplied_by_name: supplied_by_names.get(i).unwrap_or(&"").to_string(),
+                    OversightReqStatus::Pending
                 }
             })
-            .collect();
+            .unwrap_or(OversightReqStatus::Pending);
 
-        state.stations.set(mapped);
+        let manifest = window
+            .requirements
+            .iter()
+            .find(|r| r.label == "ManifestCreated")
+            .map(|r| {
+                if r.met {
+                    OversightReqStatus::Met
+                } else {
+                    OversightReqStatus::Pending
+                }
+            })
+            .unwrap_or(OversightReqStatus::Pending);
+
+        state.oversight.set(OversightState {
+            visible: true,
+            handler_id: window.handler_id,
+            gate_title: "Cargo Unloading Gate".into(),
+            arrival_status: arrival,
+            manifest_status: manifest,
+        });
+    } else {
+        state.oversight.set(OversightState::default());
     }
 }
 
-fn hydrate_oversight(state: AppState, base: String, sid: String) {
-    spawn_local(async move {
-        let url = format!("{base}/admin/oversight/windows?session_id={sid}");
-        let resp = match gloo_net::http::Request::get(&url).send().await {
-            Ok(r) => r,
-            Err(_) => return,
-        };
-
-        if !resp.ok() {
-            return;
-        }
-
-        let windows: Vec<OversightWindowResponse> = match resp.json().await {
-            Ok(w) => w,
-            Err(_) => return,
-        };
-
-        // Show the first pending window in the oversight strip
-        if let Some(window) = windows.into_iter().find(|w| w.status == "pending") {
-            let arrival = window
-                .requirements
+fn map_cargo(cargo: GameCargoResponse, stations: &[StationDef]) -> Option<crate::state::CargoLoad> {
+    let destination_idx = cargo
+        .destination_station_id
+        .and_then(|destination_station_id| {
+            stations
                 .iter()
-                .find(|r| r.label == "ShipArrivedAtStation")
-                .map(|r| {
-                    if r.met {
-                        OversightReqStatus::Met
-                    } else {
-                        OversightReqStatus::Pending
-                    }
-                })
-                .unwrap_or(OversightReqStatus::Pending);
+                .position(|station| station.id == destination_station_id)
+        })?;
 
-            let manifest = window
-                .requirements
-                .iter()
-                .find(|r| r.label == "ManifestCreated")
-                .map(|r| {
-                    if r.met {
-                        OversightReqStatus::Met
-                    } else {
-                        OversightReqStatus::Pending
-                    }
-                })
-                .unwrap_or(OversightReqStatus::Pending);
-
-            state.oversight.set(OversightState {
-                visible: true,
-                handler_id: window.handler_id,
-                gate_title: "Cargo Unloading Gate".into(),
-                arrival_status: arrival,
-                manifest_status: manifest,
-            });
-        }
-    });
+    Some(crate::state::CargoLoad {
+        destination_idx,
+        amount_pct: cargo.amount_pct,
+        manifest_id: Some(cargo.manifest_id),
+    })
 }
 
-fn hydrate_dead_letters(state: AppState, base: String, sid: String) {
-    spawn_local(async move {
-        let url = format!("{base}/admin/deadletters?session_id={sid}");
-        let resp = match gloo_net::http::Request::get(&url).send().await {
-            Ok(r) => r,
-            Err(_) => return,
-        };
+fn map_ship(ship: ShipStateResponse, stations: &[StationDef]) -> ShipState {
+    let status = match ship.status.as_str() {
+        "docked" | "Docked" => ShipStatus::Docked,
+        "transit" | "Transit" => ShipStatus::Transit,
+        "dead" | "Dead" => ShipStatus::Dead,
+        _ => ShipStatus::Docked,
+    };
 
-        if !resp.ok() {
-            return;
-        }
+    let station_positions = default_station_positions();
+    let station_idx = ship
+        .station_id
+        .and_then(|sid| stations.iter().position(|station| station.id == sid));
+    let (left, top) = station_idx
+        .and_then(|idx| station_positions.get(idx))
+        .copied()
+        .unwrap_or((48.0, 44.0));
 
-        let entries: Vec<DeadLetterEntry> = match resp.json().await {
-            Ok(e) => e,
-            Err(_) => return,
-        };
+    let snapshot_every = 50u32;
+    let events_since = (ship
+        .aggregate_version
+        .saturating_sub(ship.last_snapshot_version) as u32)
+        % snapshot_every;
 
-        state.dead_letters.set(entries);
+    ShipState {
+        id: ship.id,
+        name: ship.name,
+        status,
+        fuel_pct: ship.fuel_pct as f32,
+        version: ship.aggregate_version,
+        events_since_snapshot: events_since,
+        snapshot_every,
+        current_station_idx: station_idx,
+        destination_station_idx: None,
+        left_pct: left,
+        top_pct: top,
+        canvas_x: None,
+        canvas_y: None,
+        from_pct_x: None,
+        from_pct_y: None,
+        flight_start_ms: None,
+        flight_duration_ms: None,
+    }
+}
+
+fn map_stations(mut stations: Vec<StationStateResponse>) -> Vec<StationDef> {
+    if stations.is_empty() {
+        return Vec::new();
+    }
+
+    let canonical_order = ["Alpha Depot", "Beta Relay", "Gamma Outpost", "Delta Prime"];
+    stations.sort_by_key(|station| {
+        canonical_order
+            .iter()
+            .position(|&name| name == station.name)
+            .unwrap_or(usize::MAX)
     });
+
+    let positions = default_station_positions();
+    let planet_color_vars = [
+        "--planet-green",
+        "--planet-purple",
+        "--planet-coral",
+        "--planet-blue",
+    ];
+    let planet_radii = [32.0, 22.0, 28.0, 20.0];
+    let has_rings = [false, true, false, false];
+    let supplied_by_names = ["Delta Prime", "Alpha Depot", "Beta Relay", "Gamma Outpost"];
+
+    stations
+        .into_iter()
+        .enumerate()
+        .map(|(i, station)| {
+            let (left, top) = positions.get(i).copied().unwrap_or((50.0, 50.0));
+            let stock_pct = if station.capacity_kg > 0.0 {
+                (station.current_stock_kg as f64 / station.capacity_kg as f64 * 100.0)
+                    .clamp(0.0, 100.0)
+            } else {
+                0.0
+            };
+
+            StationDef {
+                id: station.id,
+                name: station.name,
+                left_pct: left,
+                top_pct: top,
+                stock_low: stock_pct < STOCK_LOW_THRESHOLD,
+                stock_pct,
+                planet_color_var: planet_color_vars.get(i).unwrap_or(&"--accent").to_string(),
+                planet_radius: planet_radii.get(i).copied().unwrap_or(20.0),
+                has_ring: has_rings.get(i).copied().unwrap_or(false),
+                capacity_kg: station.capacity_kg as f64,
+                supplied_by_name: supplied_by_names.get(i).unwrap_or(&"").to_string(),
+            }
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/canon-demo/gateway/README.md
+++ b/canon-demo/gateway/README.md
@@ -27,6 +27,7 @@ Axum REST and WebSocket gateway for the Canon demo. The gateway owns no domain l
 | `/ships/:id/history` | Event history from Cassandra |
 | `/stations` | List all stations from projection |
 | `/stations/:id/inventory` | Station inventory projection |
+| `/game/:session_id` | Session snapshot for frontend bootstrap hydration |
 | `/cargo/manifests/:id` | Manifest event history |
 | `/replay/counterfactual` | Simplified counterfactual diff |
 

--- a/canon-demo/gateway/src/routes/cargo.rs
+++ b/canon-demo/gateway/src/routes/cargo.rs
@@ -10,6 +10,8 @@ use canon_event_store::EventStore;
 use crate::command::{build_envelope, submit_command};
 use crate::correlation::{extract_correlation_id, CORRELATION_HEADER};
 use crate::error::GatewayError;
+use crate::routes::fleet::hydrate_ship_from_events;
+use crate::session::SessionManifest;
 use crate::state::AppState;
 use crate::types::{
     BeginUnloadingRequest, CommandAcceptedResponse, CreateManifestRequest, EventHistoryEntry,
@@ -40,6 +42,7 @@ async fn create_manifest(
     };
 
     submit_command(state.pool_for_service("cargo"), "ManifestState", &envelope).await?;
+    track_manifest_session_ownership(&state, &body, response.aggregate_id).await?;
 
     let mut resp_headers = HeaderMap::new();
     resp_headers.insert(
@@ -50,6 +53,42 @@ async fn create_manifest(
     );
 
     Ok((resp_headers, Json(response)))
+}
+
+async fn track_manifest_session_ownership(
+    state: &AppState,
+    body: &CreateManifestRequest,
+    manifest_id: Uuid,
+) -> Result<(), GatewayError> {
+    let ship_events = state
+        .event_store_for_service("fleet")
+        .load(&AggregateId::from_uuid(body.ship_id))
+        .await?;
+    let origin_station_id = if ship_events.is_empty() {
+        None
+    } else {
+        hydrate_ship_from_events(&ship_events, body.ship_id).station_id
+    };
+
+    let mut sessions = state.sessions.write().await;
+    if let Some(session) = sessions
+        .values_mut()
+        .find(|session| session.ids.ship_id == body.ship_id)
+    {
+        let already_known = session
+            .manifests
+            .iter()
+            .any(|manifest| manifest.manifest_id == manifest_id);
+        if !already_known {
+            session.manifests.push(SessionManifest {
+                manifest_id,
+                voyage_id: body.voyage_id,
+                origin_station_id,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 /// POST /cargo/manifests/:id/load — LoadCargo command

--- a/canon-demo/gateway/src/routes/fleet.rs
+++ b/canon-demo/gateway/src/routes/fleet.rs
@@ -306,15 +306,18 @@ async fn ship_history(
 
 // ── Ship state hydration ────────────────────────────────────────────────────
 
-struct HydratedShip {
-    name: String,
-    status: String,
-    station_id: Option<Uuid>,
-    route_label: String,
-    fuel_pct: u32,
+pub(crate) struct HydratedShip {
+    pub(crate) name: String,
+    pub(crate) status: String,
+    pub(crate) station_id: Option<Uuid>,
+    pub(crate) route_label: String,
+    pub(crate) fuel_pct: u32,
 }
 
-fn hydrate_ship_from_events(events: &[canon_core::EventEnvelope], _agg_id: Uuid) -> HydratedShip {
+pub(crate) fn hydrate_ship_from_events(
+    events: &[canon_core::EventEnvelope],
+    _agg_id: Uuid,
+) -> HydratedShip {
     let mut name = String::new();
     let mut status = "unknown".to_owned();
     let mut station_id: Option<Uuid> = None;

--- a/canon-demo/gateway/src/routes/game.rs
+++ b/canon-demo/gateway/src/routes/game.rs
@@ -1,0 +1,415 @@
+use std::collections::HashSet;
+
+use axum::extract::{Path, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use canon_core::AggregateId;
+use canon_event_store::EventStore;
+use canon_snapshot_store::SnapshotStore;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::error::GatewayError;
+use crate::state::AppState;
+use crate::types::{
+    DeadLetterResponse, GameCargoResponse, GameEventResponse, GameStateResponse,
+    OversightWindowResponse, RequirementResponse, ShipStateResponse, StationStateResponse,
+};
+
+use super::fleet::hydrate_ship_from_events;
+use super::station::hydrate_station_from_events;
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/game/:session_id", get(get_game_state))
+}
+
+#[derive(sqlx::FromRow)]
+struct WindowRow {
+    handler_id: String,
+    correlation_key: Uuid,
+    window_id: Uuid,
+    messages: serde_json::Value,
+    status: String,
+    expires_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
+struct DeadLetterRow {
+    id: Uuid,
+    handler_id: Option<String>,
+    aggregate_id: Option<Uuid>,
+    error: Option<String>,
+    attempts: i32,
+    created_at: DateTime<Utc>,
+}
+
+async fn get_game_state(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+) -> Result<Json<GameStateResponse>, GatewayError> {
+    let session_ids = {
+        let sessions = state.sessions.read().await;
+        sessions
+            .get(&session_id)
+            .map(|session| {
+                (
+                    session.ids.clone(),
+                    session.manifests.clone(),
+                    session.aggregate_id_set(),
+                )
+            })
+            .ok_or_else(|| GatewayError::NotFound(format!("session {session_id} not found")))?
+    };
+
+    let (session_ids, manifests, aggregate_ids) = session_ids;
+
+    let ship = hydrate_session_ship(&state, session_ids.ship_id).await?;
+    let stations = hydrate_session_stations(&state, &session_ids.station_ids).await?;
+    let cargo = hydrate_session_cargo(&state, &session_ids, &manifests).await?;
+    let oversight = load_session_oversight(&state, &aggregate_ids).await;
+    let dead_letters = load_session_dead_letters(&state, &aggregate_ids).await;
+    let events = load_session_events(&state, &session_ids, &manifests).await?;
+
+    Ok(Json(GameStateResponse {
+        session_id,
+        ship,
+        stations,
+        cargo,
+        oversight,
+        dead_letters,
+        events,
+    }))
+}
+
+async fn hydrate_session_ship(
+    state: &AppState,
+    ship_id: Uuid,
+) -> Result<Option<ShipStateResponse>, GatewayError> {
+    let agg_id = AggregateId::from_uuid(ship_id);
+    let event_store = state.event_store_for_service("fleet");
+    let snapshot_store = state.snapshot_store_for_service("fleet");
+    let events = event_store.load(&agg_id).await?;
+
+    if events.is_empty() {
+        return Ok(None);
+    }
+
+    let snapshot = snapshot_store.load(&agg_id).await.ok().flatten();
+    let last_snapshot_version = snapshot.as_ref().map(|s| s.version.as_u64()).unwrap_or(0);
+    let ship_state = hydrate_ship_from_events(&events, ship_id);
+    let aggregate_version = events.last().map(|e| e.version.as_u64()).unwrap_or(0);
+    let correlation_id = events
+        .last()
+        .map(|e| e.correlation_id)
+        .unwrap_or_else(Uuid::new_v4);
+
+    Ok(Some(ShipStateResponse {
+        id: ship_id,
+        name: ship_state.name,
+        status: ship_state.status,
+        station_id: ship_state.station_id,
+        route_label: ship_state.route_label,
+        fuel_pct: ship_state.fuel_pct,
+        aggregate_version,
+        last_snapshot_version,
+        correlation_id,
+    }))
+}
+
+async fn hydrate_session_stations(
+    state: &AppState,
+    station_ids: &[Uuid; 4],
+) -> Result<Vec<StationStateResponse>, GatewayError> {
+    let mut stations = Vec::with_capacity(station_ids.len());
+
+    for station_id in station_ids {
+        let agg_id = AggregateId::from_uuid(*station_id);
+        let events = state
+            .event_store_for_service("station")
+            .load(&agg_id)
+            .await?;
+        let hydrated = hydrate_station_from_events(&events);
+
+        if hydrated.registered {
+            stations.push(StationStateResponse {
+                id: *station_id,
+                name: hydrated.name,
+                capacity_kg: hydrated.capacity_kg,
+                current_stock_kg: hydrated.current_stock_kg,
+            });
+        }
+    }
+
+    Ok(stations)
+}
+
+async fn load_session_oversight(
+    state: &AppState,
+    aggregate_ids: &HashSet<Uuid>,
+) -> Option<OversightWindowResponse> {
+    let mut matches: Vec<(DateTime<Utc>, OversightWindowResponse)> = Vec::new();
+
+    for stores in state.service_stores.values() {
+        let rows: Vec<WindowRow> = sqlx::query_as(
+            "SELECT handler_id, correlation_key, window_id, messages, status, expires_at, created_at \
+             FROM inbox_windows WHERE status = 'pending' \
+             ORDER BY created_at DESC",
+        )
+        .fetch_all(&stores.pool)
+        .await
+        .unwrap_or_default();
+
+        for row in rows {
+            if !json_mentions_any_uuid(&row.messages, aggregate_ids) {
+                continue;
+            }
+
+            let now = Utc::now();
+            let messages_arr = row.messages.as_array();
+            let has_event_type = |event_type: &str| -> bool {
+                messages_arr
+                    .map(|arr| {
+                        arr.iter().any(|m| {
+                            m.get("event_type")
+                                .and_then(|v| v.as_str())
+                                .is_some_and(|t| t == event_type)
+                                || m.get("message_type")
+                                    .and_then(|v| v.as_str())
+                                    .is_some_and(|t| t == event_type)
+                        })
+                    })
+                    .unwrap_or(false)
+            };
+
+            let ttl_total_secs = row
+                .expires_at
+                .map(|exp| (exp - row.created_at).num_seconds().max(0) as u32)
+                .unwrap_or(0);
+            let ttl_remaining_secs = row
+                .expires_at
+                .map(|exp| (exp - now).num_seconds().max(0) as u32)
+                .unwrap_or(0);
+
+            matches.push((
+                row.created_at,
+                OversightWindowResponse {
+                    window_id: row.window_id,
+                    handler_id: row.handler_id,
+                    correlation_key: row.correlation_key,
+                    ship_name: String::new(),
+                    dest_label: String::new(),
+                    status: row.status,
+                    requirements: vec![
+                        RequirementResponse {
+                            label: "ShipArrivedAtStation".to_owned(),
+                            met: has_event_type("ShipArrivedAtStation"),
+                        },
+                        RequirementResponse {
+                            label: "ManifestCreated".to_owned(),
+                            met: has_event_type("ManifestCreated"),
+                        },
+                    ],
+                    ttl_remaining_secs,
+                    ttl_total_secs,
+                },
+            ));
+        }
+    }
+
+    matches.sort_by(|a, b| b.0.cmp(&a.0));
+    matches.into_iter().map(|(_, window)| window).next()
+}
+
+async fn load_session_dead_letters(
+    state: &AppState,
+    aggregate_ids: &HashSet<Uuid>,
+) -> Vec<DeadLetterResponse> {
+    let mut entries: Vec<(DateTime<Utc>, DeadLetterResponse)> = Vec::new();
+
+    for (service_name, stores) in &state.service_stores {
+        let rows: Vec<DeadLetterRow> = sqlx::query_as(
+            "SELECT id, handler_id, aggregate_id, error, attempts, created_at \
+             FROM dead_letters ORDER BY created_at DESC",
+        )
+        .fetch_all(&stores.pool)
+        .await
+        .unwrap_or_default();
+
+        for row in rows {
+            let Some(aggregate_id) = row.aggregate_id else {
+                continue;
+            };
+            if !aggregate_ids.contains(&aggregate_id) {
+                continue;
+            }
+
+            let service = row.handler_id.unwrap_or_else(|| service_name.clone());
+            let created_at = row.created_at;
+            entries.push((
+                created_at,
+                DeadLetterResponse {
+                    id: row.id,
+                    event_type: "unknown".to_owned(),
+                    service,
+                    aggregate_id: aggregate_id.to_string(),
+                    error: row.error.unwrap_or_default(),
+                    attempts: row.attempts as u32,
+                    requeued: false,
+                    created_at: created_at.to_rfc3339(),
+                },
+            ));
+        }
+    }
+
+    entries.sort_by(|a, b| b.0.cmp(&a.0));
+    entries.into_iter().map(|(_, entry)| entry).collect()
+}
+
+async fn load_session_events(
+    state: &AppState,
+    session_ids: &crate::session::SessionIds,
+    manifests: &[crate::session::SessionManifest],
+) -> Result<Vec<GameEventResponse>, GatewayError> {
+    let mut entries = Vec::new();
+
+    load_events_for_aggregate(state, "fleet", session_ids.ship_id, &mut entries).await?;
+
+    for station_id in session_ids.station_ids {
+        load_events_for_aggregate(state, "station", station_id, &mut entries).await?;
+    }
+    for manifest in manifests {
+        load_events_for_aggregate(state, "cargo", manifest.manifest_id, &mut entries).await?;
+    }
+
+    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    Ok(entries)
+}
+
+async fn load_events_for_aggregate(
+    state: &AppState,
+    service: &str,
+    aggregate_id: Uuid,
+    entries: &mut Vec<GameEventResponse>,
+) -> Result<(), GatewayError> {
+    let agg_id = AggregateId::from_uuid(aggregate_id);
+    let events = state.event_store_for_service(service).load(&agg_id).await?;
+
+    entries.extend(events.into_iter().map(|event| GameEventResponse {
+        id: event.event_id,
+        timestamp: event.timestamp.to_rfc3339(),
+        version: event.version.as_u64(),
+        service: service.to_owned(),
+        event_name: event.event_type,
+        aggregate_id,
+        correlation_id: event.correlation_id,
+    }));
+
+    Ok(())
+}
+
+fn json_mentions_any_uuid(value: &serde_json::Value, aggregate_ids: &HashSet<Uuid>) -> bool {
+    match value {
+        serde_json::Value::String(raw) => Uuid::parse_str(raw)
+            .map(|id| aggregate_ids.contains(&id))
+            .unwrap_or(false),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .any(|item| json_mentions_any_uuid(item, aggregate_ids)),
+        serde_json::Value::Object(map) => map
+            .values()
+            .any(|value| json_mentions_any_uuid(value, aggregate_ids)),
+        _ => false,
+    }
+}
+
+async fn hydrate_session_cargo(
+    state: &AppState,
+    session_ids: &crate::session::SessionIds,
+    manifests: &[crate::session::SessionManifest],
+) -> Result<Option<GameCargoResponse>, GatewayError> {
+    for manifest in manifests.iter().rev() {
+        let agg_id = AggregateId::from_uuid(manifest.manifest_id);
+        let events = state.event_store_for_service("cargo").load(&agg_id).await?;
+        if events.is_empty() {
+            continue;
+        }
+
+        let hydrated = hydrate_manifest_from_events(&events);
+        if hydrated.has_active_cargo {
+            let destination_station_id =
+                next_station_id_for_origin(session_ids, manifest.origin_station_id);
+            return Ok(Some(GameCargoResponse {
+                manifest_id: manifest.manifest_id,
+                voyage_id: manifest.voyage_id,
+                destination_station_id,
+                amount_pct: 35,
+                status: hydrated.status,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+struct HydratedManifest {
+    status: String,
+    has_active_cargo: bool,
+}
+
+fn hydrate_manifest_from_events(events: &[canon_core::EventEnvelope]) -> HydratedManifest {
+    let mut status = "open".to_owned();
+    let mut active_items: HashSet<Uuid> = HashSet::new();
+
+    for event in events {
+        match event.event_type.as_str() {
+            "ManifestCreated" => {
+                status = "open".to_owned();
+            }
+            "CargoLoaded" => {
+                #[derive(serde::Deserialize)]
+                struct E {
+                    item_id: Uuid,
+                }
+                if let Ok(e) = serde_json::from_slice::<E>(&event.payload) {
+                    active_items.insert(e.item_id);
+                }
+            }
+            "UnloadingStarted" => {
+                status = "unloading".to_owned();
+            }
+            "CargoUnloaded" => {
+                #[derive(serde::Deserialize)]
+                struct E {
+                    item_id: Uuid,
+                }
+                if let Ok(e) = serde_json::from_slice::<E>(&event.payload) {
+                    active_items.remove(&e.item_id);
+                }
+            }
+            "ManifestClosed" => {
+                status = "closed".to_owned();
+                active_items.clear();
+            }
+            _ => {}
+        }
+    }
+
+    HydratedManifest {
+        status,
+        has_active_cargo: !active_items.is_empty(),
+    }
+}
+
+fn next_station_id_for_origin(
+    session_ids: &crate::session::SessionIds,
+    origin_station_id: Option<Uuid>,
+) -> Option<Uuid> {
+    let origin_station_id = origin_station_id?;
+    let origin_idx = session_ids
+        .station_ids
+        .iter()
+        .position(|station_id| *station_id == origin_station_id)?;
+    let dest_idx = (origin_idx + 1) % session_ids.station_ids.len();
+    Some(session_ids.station_ids[dest_idx])
+}

--- a/canon-demo/gateway/src/routes/mod.rs
+++ b/canon-demo/gateway/src/routes/mod.rs
@@ -2,6 +2,7 @@ mod admin;
 mod cargo;
 mod debug;
 mod fleet;
+mod game;
 mod health;
 mod navigation;
 mod replay;
@@ -28,6 +29,7 @@ pub fn build_router(state: AppState) -> Router {
         .merge(station::router())
         .merge(admin::router())
         .merge(debug::router())
+        .merge(game::router())
         .merge(replay::router())
         .merge(session::router())
         .merge(ws::router())

--- a/canon-demo/gateway/src/routes/session.rs
+++ b/canon-demo/gateway/src/routes/session.rs
@@ -73,6 +73,7 @@ async fn create_session(
         }
         let session = LiveSession {
             ids: ids.clone(),
+            manifests: Vec::new(),
             drain_handle: Some(drain_handle),
             ws_connected: Arc::new(AtomicBool::new(false)),
         };

--- a/canon-demo/gateway/src/routes/station.rs
+++ b/canon-demo/gateway/src/routes/station.rs
@@ -231,14 +231,14 @@ async fn station_inventory(
 
 // ── Station state hydration ────────────────────────────────────────────────
 
-struct HydratedStation {
-    name: String,
-    capacity_kg: f32,
-    current_stock_kg: f32,
-    registered: bool,
+pub(crate) struct HydratedStation {
+    pub(crate) name: String,
+    pub(crate) capacity_kg: f32,
+    pub(crate) current_stock_kg: f32,
+    pub(crate) registered: bool,
 }
 
-fn hydrate_station_from_events(events: &[canon_core::EventEnvelope]) -> HydratedStation {
+pub(crate) fn hydrate_station_from_events(events: &[canon_core::EventEnvelope]) -> HydratedStation {
     let mut name = String::new();
     let mut capacity_kg: f32 = 0.0;
     let mut current_stock_kg: f32 = 0.0;

--- a/canon-demo/gateway/src/routes/ws.rs
+++ b/canon-demo/gateway/src/routes/ws.rs
@@ -4,7 +4,6 @@
 //! session_id. After that, only events matching the session's aggregate IDs
 //! are forwarded. InfraStatus messages always pass through.
 
-use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -39,18 +38,15 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     let (mut sender, mut receiver) = socket.split();
     let mut rx = state.event_tx.subscribe();
 
-    // Session filter: None until RegisterSession is received.
-    let filter: Arc<RwLock<Option<HashSet<Uuid>>>> = Arc::new(RwLock::new(None));
     let session_id: Arc<RwLock<Option<Uuid>>> = Arc::new(RwLock::new(None));
 
     // Send task: forward matching broadcast events to this client.
-    let filter_send = filter.clone();
+    let session_id_send = session_id.clone();
+    let sessions_send = state.sessions.clone();
     let send_task = tokio::spawn(async move {
         while let Ok(msg) = rx.recv().await {
-            let forward = {
-                let f = filter_send.read().await;
-                should_forward(&msg, f.as_ref())
-            };
+            let sid = *session_id_send.read().await;
+            let forward = should_forward(&msg, sid, &sessions_send).await;
             if forward && sender.send(Message::Text(msg)).await.is_err() {
                 break;
             }
@@ -58,7 +54,6 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     });
 
     // Receive task: listen for RegisterSession messages from the client.
-    let filter_recv = filter.clone();
     let session_id_recv = session_id.clone();
     let sessions = state.sessions.clone();
     let recv_task = tokio::spawn(async move {
@@ -69,10 +64,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                         if reg.msg_type == "RegisterSession" {
                             let store = sessions.read().await;
                             if let Some(session) = store.get(&reg.session_id) {
-                                let id_set = session.ids.aggregate_id_set();
                                 session.ws_connected.store(true, Ordering::Relaxed);
-                                let mut f = filter_recv.write().await;
-                                *f = Some(id_set);
                                 let mut sid = session_id_recv.write().await;
                                 *sid = Some(reg.session_id);
                                 tracing::info!(session_id = %reg.session_id, "WS registered session");
@@ -140,22 +132,33 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 }
 
 /// Check if a broadcast message should be forwarded to this session's WS.
-fn should_forward(json: &str, filter: Option<&HashSet<Uuid>>) -> bool {
+async fn should_forward(
+    json: &str,
+    session_id: Option<Uuid>,
+    sessions: &crate::session::SessionStore,
+) -> bool {
     // InfraStatus always passes through
     if json.contains("\"type\":\"InfraStatus\"") {
         return true;
     }
 
-    let filter = match filter {
-        Some(f) => f,
+    let session_id = match session_id {
+        Some(session_id) => session_id,
         None => return false, // No session registered yet
+    };
+    let aggregate_ids = {
+        let store = sessions.read().await;
+        match store.get(&session_id) {
+            Some(session) => session.aggregate_id_set(),
+            None => return false,
+        }
     };
 
     // Fast-path: check aggregate_id field
     if let Ok(val) = serde_json::from_str::<serde_json::Value>(json) {
         if let Some(agg_str) = val.get("aggregate_id").and_then(|v| v.as_str()) {
             if let Ok(agg_uuid) = Uuid::parse_str(agg_str) {
-                if filter.contains(&agg_uuid) {
+                if aggregate_ids.contains(&agg_uuid) {
                     return true;
                 }
             }
@@ -167,7 +170,7 @@ fn should_forward(json: &str, filter: Option<&HashSet<Uuid>>) -> bool {
             for field in &["station_id", "ship_id"] {
                 if let Some(id_str) = payload.get(*field).and_then(|v| v.as_str()) {
                     if let Ok(id_uuid) = Uuid::parse_str(id_str) {
-                        if filter.contains(&id_uuid) {
+                        if aggregate_ids.contains(&id_uuid) {
                             return true;
                         }
                     }

--- a/canon-demo/gateway/src/session.rs
+++ b/canon-demo/gateway/src/session.rs
@@ -37,12 +37,33 @@ impl SessionIds {
     }
 }
 
+/// Metadata for manifests created during a session.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionManifest {
+    pub manifest_id: Uuid,
+    pub voyage_id: Uuid,
+    pub origin_station_id: Option<Uuid>,
+}
+
 /// A live session with its drain task handle.
 pub struct LiveSession {
     pub ids: SessionIds,
+    pub manifests: Vec<SessionManifest>,
     pub drain_handle: Option<JoinHandle<()>>,
     /// True while a WS is connected for this session.
     pub ws_connected: Arc<AtomicBool>,
+}
+
+impl LiveSession {
+    /// Returns all aggregate IDs that belong to this session, including
+    /// manifests created through the gateway during play.
+    pub fn aggregate_id_set(&self) -> HashSet<Uuid> {
+        let mut set = self.ids.aggregate_id_set();
+        for manifest in &self.manifests {
+            set.insert(manifest.manifest_id);
+        }
+        set
+    }
 }
 
 /// Thread-safe store of active sessions.

--- a/canon-demo/gateway/src/types.rs
+++ b/canon-demo/gateway/src/types.rs
@@ -36,6 +36,39 @@ pub struct StationInventoryResponse {
     pub current_stock_kg: f32,
 }
 
+// ── Session snapshot (GET /game/:session_id) ────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GameStateResponse {
+    pub session_id: Uuid,
+    pub ship: Option<ShipStateResponse>,
+    pub stations: Vec<StationStateResponse>,
+    pub cargo: Option<GameCargoResponse>,
+    pub oversight: Option<OversightWindowResponse>,
+    pub dead_letters: Vec<DeadLetterResponse>,
+    pub events: Vec<GameEventResponse>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GameCargoResponse {
+    pub manifest_id: Uuid,
+    pub voyage_id: Uuid,
+    pub destination_station_id: Option<Uuid>,
+    pub amount_pct: u32,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GameEventResponse {
+    pub id: Uuid,
+    pub timestamp: String,
+    pub version: u64,
+    pub service: String,
+    pub event_name: String,
+    pub aggregate_id: Uuid,
+    pub correlation_id: Uuid,
+}
+
 // ── Oversight windows (GET /admin/oversight/windows) ─────────────────────────
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
- add a session-scoped  snapshot endpoint for frontend bootstrap hydration
- switch frontend hydration to a single snapshot fetch and restore event log, oversight, dead letters, and cargo state from it
- track session-owned manifest aggregates in the gateway so cargo events and reload recovery stay session-scoped

## Testing
- cargo test -p gateway --no-run
- cargo test -p frontend --no-run