### PR TITLE
fix(k8s): replace no-op IP annotation with Cloud Armor security policy

### DIFF
--- a/canon-demo/k8s/overlays/gke/staging/backend-config.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/backend-config.yaml
@@ -1,3 +1,35 @@
+# Cloud Armor security policy for IP-based access control on staging.
+#
+# GKE Ingress does NOT support IP allowlisting via annotations (e.g.
+# cloud.google.com/ingress-allow-list is silently ignored). The only way
+# to restrict access by source IP is a Cloud Armor security policy
+# referenced here in the BackendConfig.
+#
+# Create the policy before deploying (one-time):
+#
+#   gcloud compute security-policies create canon-staging-ip-allowlist \
+#     --description "Staging IP allowlist for Canon demo"
+#
+#   # Default rule: deny all
+#   gcloud compute security-policies rules update 2147483647 \
+#     --security-policy canon-staging-ip-allowlist \
+#     --action deny-403
+#
+#   # Allow specific IPs (replace with your IPs)
+#   gcloud compute security-policies rules create 1000 \
+#     --security-policy canon-staging-ip-allowlist \
+#     --src-ip-ranges "YOUR_IP/32" \
+#     --action allow
+#
+# To add more IPs later:
+#   gcloud compute security-policies rules create 1001 \
+#     --security-policy canon-staging-ip-allowlist \
+#     --src-ip-ranges "ANOTHER_IP/32" \
+#     --action allow
+#
+# To remove the restriction (make staging public):
+#   Remove the securityPolicy block below and re-apply.
+---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
@@ -6,3 +38,5 @@ spec:
   timeoutSec: 3600
   connectionDraining:
     drainingTimeoutSec: 60
+  securityPolicy:
+    name: canon-staging-ip-allowlist

--- a/canon-demo/k8s/overlays/gke/staging/frontend-backend-config.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/frontend-backend-config.yaml
@@ -1,0 +1,13 @@
+# BackendConfig for the frontend Service in staging.
+# References the same Cloud Armor security policy as the gateway BackendConfig
+# to ensure all public-facing backends are protected by IP allowlisting.
+#
+# See backend-config.yaml for gcloud commands to create and manage the policy.
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: canon-frontend-backend-config
+spec:
+  securityPolicy:
+    name: canon-staging-ip-allowlist

--- a/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
+++ b/canon-demo/k8s/overlays/gke/staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - managed-cert.yaml
   - frontend-config.yaml
   - backend-config.yaml
+  - frontend-backend-config.yaml
   - gateway-network-policy.yaml
 
 components:
@@ -283,7 +284,7 @@ patches:
       - op: remove
         path: /spec/template/spec/initContainers
 
-  # --- Frontend Service: NodePort (required by GCE Ingress) ---
+  # --- Frontend Service: NodePort (required by GCE Ingress) + Cloud Armor ---
   - target:
       kind: Service
       name: frontend
@@ -292,6 +293,8 @@ patches:
       kind: Service
       metadata:
         name: frontend
+        annotations:
+          cloud.google.com/backend-config: '{"default":"canon-frontend-backend-config"}'
       spec:
         type: NodePort
 


### PR DESCRIPTION
## Summary

Fixes staging IP restriction — closes #325.

## What's included

- Removed reliance on invalid `cloud.google.com/ingress-allow-list` annotation
- Added `securityPolicy.name: canon-staging-ip-allowlist` to staging gateway BackendConfig
- Added new frontend BackendConfig with same Cloud Armor policy reference
- Annotated frontend Service with BackendConfig for Cloud Armor coverage
- Both public-facing backends (frontend and gateway) now reference the Cloud Armor policy

## How to apply

Create the Cloud Armor policy before deploying:
```bash
gcloud compute security-policies create canon-staging-ip-allowlist --description="Canon staging IP allowlist"
gcloud compute security-policies rules update 2147483647 --security-policy=canon-staging-ip-allowlist --action=deny-403
gcloud compute security-policies rules create 1000 --security-policy=canon-staging-ip-allowlist --src-ip-ranges="<YOUR_IP>/32" --action=allow
```

## Test plan

- [ ] `kubectl kustomize canon-demo/k8s/overlays/gke/staging/` builds cleanly
- [ ] Cloud Armor policy blocks non-allowlisted IPs when applied

🤖 Generated with [Claude Code](https://claude.ai/claude-code)