### PR TITLE
chore: add codemap setup for LLM codebase navigation

### DIFF
--- a/.codemap/config.json
+++ b/.codemap/config.json
@@ -1,0 +1,14 @@
+{
+  "only": [
+    "rs",
+    "toml",
+    "yaml",
+    "js",
+    "sql"
+  ],
+  "budgets": {},
+  "routing": {
+    "retrieval": {}
+  },
+  "drift": {}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,6 +707,24 @@ Use semantic code-navigation tools first when available: go-to-definition, find-
 hover for type info, and workspace symbol search. Fall back to `rg`/glob only when semantic
 tools do not cover what you need.
 
+### codemap
+
+`codemap` is installed in this repo. Use it to orient yourself before making changes — it tells you the shape of the codebase, what's changed, and which files are high blast-radius hubs.
+
+```bash
+codemap .                  # full repo tree (respects .codemap/config.json)
+codemap --diff             # what's changed vs main — run this before every PR
+codemap --deps .           # dependency flow between modules
+codemap blast-radius .     # risk analysis for current working set
+codemap handoff --latest . # read the latest handoff artifact from the previous session
+```
+
+**Rules:**
+- Run `codemap --diff` before starting any task so you know what's already in flight.
+- If codemap warns `⚠ <file> is used by N other files`, treat that file as a hub — changes to it affect N consumers. Be conservative.
+- Run `codemap handoff --latest .` at session start to pick up context from the previous agent session.
+- Run `codemap handoff .` before ending a session so the next agent can continue without re-briefing.
+
 ---
 ## What to do when stuck
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -754,6 +754,24 @@ See `canon-demo/frontend/Cargo.toml` for dependencies. See `canon-demo/frontend/
 
 Always use the LSP tool first when exploring the codebase — go-to-definition, find-references, hover for type info, and workspace symbol search. Fall back to Grep/Glob only when LSP doesn't cover what you need.
 
+### codemap
+
+`codemap` is installed in this repo. Use it to orient yourself before making changes — it tells you the shape of the codebase, what's changed, and which files are high blast-radius hubs.
+
+```bash
+codemap .                  # full repo tree (respects .codemap/config.json)
+codemap --diff             # what's changed vs main — run this before every PR
+codemap --deps .           # dependency flow between modules
+codemap blast-radius .     # risk analysis for current working set
+codemap handoff .          # read the latest handoff artifact from the previous session
+```
+
+**Rules:**
+- Run `codemap --diff` before starting any task so you know what's already in flight.
+- If codemap warns `⚠ <file> is used by N other files`, treat that file as a hub — changes to it affect N consumers. Be conservative.
+- Run `codemap handoff --latest .` at session start to pick up context from the previous agent session.
+- Run `codemap handoff .` before ending a session so the next agent can continue without re-briefing.
+
 ---
 ## Debugging protocol — when the demo is broken
 


### PR DESCRIPTION
## What

Installs and configures [codemap](https://github.com/JordanCoin/codemap) — a project intelligence layer that gives LLMs instant architectural context without burning tokens.

## Changes

- **`.codemap/config.json`** — per-project config auto-detected for the Canon workspace (filters to `rs, toml, yaml, js, sql`)
- **`CLAUDE.md`** — codemap usage section so Claude Code knows to use it
- **`AGENTS.md`** — same section for other LLMs (Codex, Gemini, Cursor, etc.)

## Why

Without this, every LLM session starts blind — it has to spend tokens exploring the repo structure before it can do useful work. codemap pre-computes:

- Full repo tree with file sizes and extension breakdown
- What's changed vs `main` and which hub files are affected
- Dependency flow between modules
- Handoff artifacts so agents can continue where the last one left off

The hooks in `.claude/settings.local.json` (installed separately via `codemap setup`) handle automatic context injection for Claude Code sessions. The CLAUDE.md/AGENTS.md instructions cover every other LLM.