### PR TITLE
perf(demo): serve 304 Not Modified on idle /game polls

### DIFF
--- a/canon-demo/frontend/src/hydrate.rs
+++ b/canon-demo/frontend/src/hydrate.rs
@@ -100,19 +100,52 @@ pub struct GameEventResponse {
 
 pub fn hydrate_from_gateway(state: AppState, session_id: Uuid) {
     spawn_local(async move {
-        if let Some(snapshot) = fetch_game_state(session_id).await {
-            apply_snapshot(state, snapshot);
+        if let FetchResult::Snapshot { snapshot, .. } = fetch_game_state(session_id, None).await {
+            apply_snapshot(state, *snapshot);
         }
     });
 }
 
-pub async fn fetch_game_state(session_id: Uuid) -> Option<GameStateResponse> {
+/// Outcome of a `GET /game/:id` poll.
+///
+/// `NotModified` is returned when the server answered `304` — the caller
+/// keeps its previously-applied state and skips the signal update pass.
+/// The snapshot is boxed to keep all variants roughly the same size
+/// (satisfies `clippy::large_enum_variant`).
+pub enum FetchResult {
+    Snapshot {
+        snapshot: Box<GameStateResponse>,
+        etag: Option<String>,
+    },
+    NotModified,
+    Error,
+}
+
+pub async fn fetch_game_state(session_id: Uuid, if_none_match: Option<&str>) -> FetchResult {
     let url = format!("{}/game/{}", gateway_base_url(), session_id);
-    let resp = gloo_net::http::Request::get(&url).send().await.ok()?;
-    if !resp.ok() {
-        return None;
+    let mut req = gloo_net::http::Request::get(&url);
+    if let Some(etag) = if_none_match {
+        req = req.header("If-None-Match", etag);
     }
-    resp.json().await.ok()
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(_) => return FetchResult::Error,
+    };
+
+    match resp.status() {
+        304 => FetchResult::NotModified,
+        200 => {
+            let etag = resp.headers().get("etag");
+            match resp.json::<GameStateResponse>().await {
+                Ok(snapshot) => FetchResult::Snapshot {
+                    snapshot: Box::new(snapshot),
+                    etag,
+                },
+                Err(_) => FetchResult::Error,
+            }
+        }
+        _ => FetchResult::Error,
+    }
 }
 
 pub fn apply_snapshot(state: AppState, snapshot: GameStateResponse) {

--- a/canon-demo/frontend/src/polling.rs
+++ b/canon-demo/frontend/src/polling.rs
@@ -1,17 +1,19 @@
 //! HTTP polling client for game state.
 //!
 //! Creates a session via POST /sessions, then polls GET /game/:session_id
-//! adaptively. Active gameplay polls at 100ms; idle/background states back off.
+//! adaptively. Requests carry `If-None-Match` so the server answers `304`
+//! when the projection has not advanced — most polls cost <100 bytes and
+//! issue zero DB queries on the gateway.
 
 use leptos::prelude::*;
 
 use crate::gateway::gateway_base_url;
-use crate::hydrate::{apply_snapshot, fetch_game_state};
+use crate::hydrate::{apply_snapshot, fetch_game_state, FetchResult};
 use crate::state::{AppState, ConnectionStatus, PendingCommand, ShipStatus};
 
-const ACTIVE_POLL_INTERVAL_MS: u32 = 100;
-const IDLE_POLL_INTERVAL_MS: u32 = 500;
-const BACKGROUND_POLL_INTERVAL_MS: u32 = 1_000;
+const ACTIVE_POLL_INTERVAL_MS: u32 = 250;
+const IDLE_POLL_INTERVAL_MS: u32 = 1_000;
+const BACKGROUND_POLL_INTERVAL_MS: u32 = 2_000;
 
 /// Number of consecutive poll failures before assuming the session is stale
 /// (e.g., gateway restarted during a deploy) and creating a new one.
@@ -60,12 +62,16 @@ pub fn start_session_and_poll(state: AppState) {
         state.session_id.set(Some(session.session_id));
         state.connection.set(ConnectionStatus::Connected);
 
-        // Initial hydration
-        if let Some(snapshot) = fetch_game_state(session.session_id).await {
-            apply_snapshot(state, snapshot);
+        // Initial hydration captures the first ETag for the loop below.
+        let mut last_etag: Option<String> = None;
+        let mut last_session_id = session.session_id;
+        if let FetchResult::Snapshot { snapshot, etag } =
+            fetch_game_state(session.session_id, None).await
+        {
+            apply_snapshot(state, *snapshot);
+            last_etag = etag;
         }
 
-        // Poll loop
         let mut consecutive_failures: u32 = 0;
         loop {
             gloo_timers::future::TimeoutFuture::new(next_poll_interval_ms(&state)).await;
@@ -74,19 +80,31 @@ pub fn start_session_and_poll(state: AppState) {
                 continue;
             };
 
-            match fetch_game_state(session_id).await {
-                Some(snapshot) => {
+            // Session rotated (e.g. gateway redeployed) — discard the old ETag
+            // so the next request starts from scratch with the new projection.
+            if session_id != last_session_id {
+                last_session_id = session_id;
+                last_etag = None;
+            }
+
+            match fetch_game_state(session_id, last_etag.as_deref()).await {
+                FetchResult::Snapshot { snapshot, etag } => {
                     consecutive_failures = 0;
-                    apply_snapshot(state, snapshot);
+                    apply_snapshot(state, *snapshot);
+                    last_etag = etag;
                     if state.connection.get_untracked() != ConnectionStatus::Connected {
                         state.connection.set(ConnectionStatus::Connected);
                     }
                 }
-                None => {
+                FetchResult::NotModified => {
+                    consecutive_failures = 0;
+                    if state.connection.get_untracked() != ConnectionStatus::Connected {
+                        state.connection.set(ConnectionStatus::Connected);
+                    }
+                }
+                FetchResult::Error => {
                     consecutive_failures += 1;
                     if consecutive_failures >= MAX_POLL_FAILURES {
-                        // Session is stale (gateway restarted during deploy).
-                        // Restart with a fresh session.
                         web_sys::console::warn_1(
                             &format!(
                                 "Session {session_id} lost after {consecutive_failures} poll failures, reconnecting"

--- a/canon-demo/gateway/src/main.rs
+++ b/canon-demo/gateway/src/main.rs
@@ -138,7 +138,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap_or_else(|_| axum::http::HeaderValue::from_static("http://localhost:3000")),
         )
         .allow_methods(Any)
-        .allow_headers(Any);
+        .allow_headers(Any)
+        .expose_headers([axum::http::header::ETAG]);
 
     // ── Router ──────────────────────────────────────────────────────────────
     let app = routes::build_router(state).layer(cors);

--- a/canon-demo/gateway/src/projection.rs
+++ b/canon-demo/gateway/src/projection.rs
@@ -123,6 +123,8 @@ pub struct GameProjection {
     pub tracked_ids: HashSet<Uuid>,
     /// Game over when any station hits 0%.
     pub game_over: bool,
+    /// Monotonic counter bumped on every `apply_event`. Drives ETag / 304.
+    pub version: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +169,7 @@ impl GameProjection {
             event_count: 0,
             tracked_ids,
             game_over: false,
+            version: 0,
         }
     }
 
@@ -202,6 +205,11 @@ impl GameProjection {
 
         // Push to event ring buffer with dedup
         self.push_event(service, envelope);
+
+        // Bump version last so any reader seeing a higher version also sees
+        // every mutation above. Matters because /game/:id reads version and
+        // body under the same lock.
+        self.version = self.version.wrapping_add(1);
     }
 
     /// Convert projection state to the API response type.

--- a/canon-demo/gateway/src/routes/game.rs
+++ b/canon-demo/gateway/src/routes/game.rs
@@ -3,22 +3,29 @@
 //! Reads from the in-memory game projection (sub-ms). The projection is
 //! maintained incrementally by Kafka consumers — no DB queries on the hot path.
 //! Oversight is the one exception: queried from inbox_windows on each poll.
+//!
+//! Supports conditional requests: if the client sends `If-None-Match: <v>`
+//! matching the current projection version, the response is `304 Not Modified`
+//! with an empty body and no `inbox_windows` query is issued.
 
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Path, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
+use futures::future::join_all;
 use uuid::Uuid;
 
 use tracing::warn;
 
 use crate::error::GatewayError;
 use crate::state::AppState;
-use crate::types::{GameStateResponse, OversightWindowResponse, RequirementResponse};
+use crate::types::{OversightWindowResponse, RequirementResponse};
 
 pub fn router() -> Router<AppState> {
     Router::new().route("/game/:session_id", get(game_snapshot))
@@ -28,10 +35,17 @@ pub fn router() -> Router<AppState> {
 async fn game_snapshot(
     State(state): State<AppState>,
     Path(session_id): Path<Uuid>,
-) -> Result<Json<GameStateResponse>, GatewayError> {
-    // Clone the projection Arc and update last_polled_at, then release the
-    // session store lock before doing any DB queries.
-    let (projection, tracked_ids) = {
+    headers: HeaderMap,
+) -> Result<Response, GatewayError> {
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_etag);
+
+    // Clone the projection Arc, update last_polled_at, and read current version
+    // under a brief read lock. Release the session store + projection lock
+    // before any DB work.
+    let (projection, tracked_ids, current_version) = {
         let sessions = state.sessions.read().await;
         let session = sessions
             .get(&session_id)
@@ -45,25 +59,61 @@ async fn game_snapshot(
 
         let proj = session.projection.read().await;
         let ids = proj.tracked_ids.clone();
+        let version = proj.version;
         drop(proj);
 
-        (session.projection.clone(), ids)
+        (session.projection.clone(), ids, version)
     };
 
-    // Query oversight OUTSIDE any projection lock — this is a DB query that
-    // can take 10-50ms. Previously we held a write lock during this query,
-    // which blocked Kafka consumers from applying events to the projection
-    // and caused intermittent timeouts under concurrent multi-session load.
+    // Fast path: client already has the latest projection version. Skip the
+    // oversight DB query and return 304 with just an ETag.
+    if if_none_match == Some(current_version) {
+        return Ok(not_modified(current_version));
+    }
+
+    // Query oversight in parallel across every service pool. Each query is
+    // independent; serialising them (prior behaviour) multiplied the DB cost
+    // by the number of services per poll.
     let oversight = query_first_oversight_window(&state, &tracked_ids).await;
 
-    // Brief write lock just to set oversight, then immediately build response
-    // and release. The Kafka consumer only contends for this lock for
-    // microseconds instead of the full DB query duration.
+    // Brief write lock: set oversight and build the response. The version
+    // read above is the lower bound — if a Kafka consumer applied an event
+    // between the two locks, the response reflects the newer state (and a
+    // higher ETag) which is fine.
     let mut proj = projection.write().await;
     proj.oversight = oversight;
+    let etag_version = proj.version;
     let infra = state.infra_status.read().await;
     let response = proj.to_game_state_response(&infra);
-    Ok(Json(response))
+    drop(proj);
+
+    Ok(ok_with_etag(response, etag_version))
+}
+
+fn not_modified(version: u64) -> Response {
+    let mut resp = StatusCode::NOT_MODIFIED.into_response();
+    resp.headers_mut()
+        .insert(header::ETAG, etag_header_value(version));
+    resp
+}
+
+fn ok_with_etag(body: crate::types::GameStateResponse, version: u64) -> Response {
+    let mut resp = Json(body).into_response();
+    *resp.status_mut() = StatusCode::OK;
+    resp.headers_mut()
+        .insert(header::ETAG, etag_header_value(version));
+    resp
+}
+
+fn etag_header_value(version: u64) -> HeaderValue {
+    // Weak ETag — the body is semantically identical per-version but
+    // oversight TTL seconds are time-derived and vary between polls.
+    HeaderValue::from_str(&format!("W/\"{version}\"")).expect("numeric etag is always valid ascii")
+}
+
+fn parse_etag(header: &str) -> Option<u64> {
+    let trimmed = header.trim().trim_start_matches("W/").trim_matches('"');
+    trimmed.parse::<u64>().ok()
 }
 
 // ── Oversight window query ─────────────────────────────────────────────────
@@ -83,23 +133,29 @@ async fn query_first_oversight_window(
     state: &AppState,
     tracked_ids: &HashSet<Uuid>,
 ) -> Option<OversightWindowResponse> {
-    let mut candidates = Vec::new();
+    // Fire one query per service pool in parallel. 5 services × sequential
+    // ~10-50ms per query previously stacked to 50-250ms per poll; running
+    // them concurrently caps the latency at the slowest single query.
+    let queries = state.service_stores.values().map(|stores| {
+        let pool = stores.pool.clone();
+        async move {
+            let rows: Result<Vec<WindowRow>, _> = sqlx::query_as(
+                "SELECT handler_id, correlation_key, window_id, messages, status, expires_at, created_at \
+                 FROM inbox_windows WHERE status = 'pending' ORDER BY created_at DESC LIMIT 20",
+            )
+            .fetch_all(&pool)
+            .await;
+            rows
+        }
+    });
 
-    for stores in state.service_stores.values() {
-        let rows: Vec<WindowRow> = match sqlx::query_as(
-            "SELECT handler_id, correlation_key, window_id, messages, status, expires_at, created_at \
-             FROM inbox_windows WHERE status = 'pending' ORDER BY created_at DESC LIMIT 20",
-        )
-        .fetch_all(&stores.pool)
-        .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(error = %e, "failed to query inbox_windows for oversight");
-                continue;
-            }
-        };
-        candidates.extend(rows);
+    let results = join_all(queries).await;
+    let mut candidates: Vec<WindowRow> = Vec::new();
+    for res in results {
+        match res {
+            Ok(rows) => candidates.extend(rows),
+            Err(e) => warn!(error = %e, "failed to query inbox_windows for oversight"),
+        }
     }
 
     candidates.sort_by_key(|c| std::cmp::Reverse(c.created_at));
@@ -170,5 +226,26 @@ fn json_contains_any_uuid(value: &serde_json::Value, tracked_ids: &HashSet<Uuid>
             .values()
             .any(|item| json_contains_any_uuid(item, tracked_ids)),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_etag;
+
+    #[test]
+    fn parses_strong_etag() {
+        assert_eq!(parse_etag("\"42\""), Some(42));
+    }
+
+    #[test]
+    fn parses_weak_etag() {
+        assert_eq!(parse_etag("W/\"42\""), Some(42));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_etag("nope"), None);
+        assert_eq!(parse_etag("\"\""), None);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a monotonic `version: u64` to `GameProjection`, bumped on every `apply_event`.
- `GET /game/:session_id` honours `If-None-Match` and returns `304` with `ETag: W/"<version>"` when the client is already up-to-date. No oversight DB query is issued on the 304 path.
- Parallelises the oversight `inbox_windows` queries across service pools with `futures::future::join_all` (was sequential).
- Frontend tracks per-session ETag, sends `If-None-Match` on every poll, and skips the signal-apply pass on 304.
- Poll cadence eased from 100 / 500 / 1000 ms to 250 / 1000 / 2000 ms (active / idle / tab-hidden) now that per-poll cost is effectively zero.
- CORS layer exposes the `ETag` response header.

## Why

Devtools on the live demo showed a wall of `200` responses at ~10 req/s, each ~4 kB, and every poll fan-out triggered 5 × `inbox_windows` queries. Idle gameplay was costing ~40 kB/s network and ~50 DB queries/s per session. Under this PR, the steady-state poll is a 304 with an empty body and zero DB traffic; only real state changes (events applied to the projection) trigger a 200 with a body.

## Verified live

Deployed and tested against `canon.mopjones.com`:
- `curl -H 'If-None-Match: W/"N"' /game/:id` returns `304` when the projection is at version N.
- Playwright smoke test: clicking Beta Relay → ship departs → arrives → log fills. Over ~10 s of idle gameplay: 3 × 200 + 34 × 304.
- No regression in behaviour; apply-snapshot semantics unchanged.

## Test plan
- [x] `cargo test -p gateway` (includes new ETag parser tests)
- [x] `cargo check --workspace` clean
- [x] Frontend WASM builds via Trunk
- [x] End-to-end flow on live GKE: depart → transit → dock
- [x] Devtools shows 304s with 0.0 kB bodies on idle polls