### PR TITLE
chore: pause GKE demo, serve static site from GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,16 @@
 name: Deploy to GKE
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'canon-demo/**'
-      - 'canon-site/**'
-      - 'canon-*/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
   workflow_dispatch:
+  # Auto-deploy disabled — demo cluster is paused to save cost.
+  # Re-enable by uncommenting the push trigger and running `make gke-resume`.
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'canon-demo/**'
+  #     - 'canon-*/**'
+  #     - 'Cargo.toml'
+  #     - 'Cargo.lock'
 
 permissions:
   id-token: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'canon-site/**'
+      - 'canon-docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C $HOME/.cargo/bin
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Build mdBook docs
+        run: |
+          cd canon-docs
+          mdbook build
+
+      - name: Stage site
+        run: |
+          mkdir -p _site
+          cp -r canon-site/. _site/
+          mkdir -p _site/docs
+          cp -r canon-docs/book/. _site/docs/
+          # codemap.html lives at canon-site root → /codemap (no .html on Pages)
+          if [ -f _site/codemap.html ] && [ ! -d _site/codemap ]; then
+            mkdir -p _site/codemap
+            mv _site/codemap.html _site/codemap/index.html
+          fi
+          # custom domain
+          echo "canon.mopjones.com" > _site/CNAME
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,877 +1,185 @@
 # Canon — Claude Code guide
 
-Canon is a Rust event sourcing framework. This file is the authoritative reference. The design is settled — your job is implementation, not design.
+Rust event sourcing framework. Design settled. Job: implementation.
+
+Demo specifics: `canon-demo/CLAUDE.md`. Frontend: `canon-demo/frontend/CLAUDE.md`.
 
 ---
 
 ## Pipeline
 
 ```
-External world → canon-adaptor-kafka → canon-inbox-yugabyte → canon-inbound-queue-kafka
-    → Dispatcher (command handler | internal event handlers | external event handlers)
-    → YugabyteDB txn (commands table + outbox table)
-    → Outbox processor → canon-outbound-queue-kafka
-    → Event store consumer (Cassandra + snapshots)
-    → Projection consumer (YugabyteDB read models)
-    → Internal event consumer → inbox (for event handler dispatch)
-    → canon-publisher-kafka → canon.{service}.events → other services
+External → canon-adaptor-kafka → canon-inbox-yugabyte → canon-inbound-queue-kafka
+  → Dispatcher (command | internal events | external events)
+  → YugabyteDB txn (commands + outbox)
+  → Outbox processor → canon-outbound-queue-kafka
+  → 4 consumers: event store (Cassandra+snapshots) | projections | publisher | internal-event re-entry
+  → canon-publisher-kafka → canon.{service}.events
 ```
 
-All Kafka topics partitioned by `aggregate_id`.
+All Kafka topics partitioned by `aggregate_id`. Every stage must be wired and covered by an e2e test. A component that compiles but is never called is not implemented.
 
-Every stage in this pipeline must be wired, tested end-to-end, and verified with
-`/test-demo`. A component that compiles but is never called is not implemented.
+---
+
+## Workspace
+
+```
+canon-core (traits + types + in-memory + canon-core-macros)
+  ↓
+canon-{event-store,command-store,snapshot-store,inbox,inbound-queue,
+       outbound-queue,projection-store,publisher,adaptor,deadletter}
+  ↓
+canon-{event-store-cassandra,*-yugabyte,*-kafka}
+canon-test           ← integration tests (in-memory + testcontainers)
+canon-demo/          ← services, gateway, frontend
+canon-site/, canon-docs/
+```
+
+Strict DAG: impl crates depend on their trait crate + `canon-core` only. No cross-impl deps.
+
+Run `codemap --diff` before any task. Run `codemap handoff` at session boundaries.
 
 ---
 
 ## Non-negotiable rules
 
-- **tokio only**. No async-std. `async_trait` throughout. No manual `Pin<Box<dyn Future>>`.
-- **`thiserror`** in every crate. No `anyhow`. No god error enum. Each crate owns its errors.
-- **`AggregateId(Uuid)`** newtype always. Never generic, never plain `Uuid`.
-- **Proc-macros** live in the crate that owns the concept. No separate `canon-macros` crate.
-- **Strict DAG**: impl crates depend on their trait crate + `canon-core` only. No cross-impl dependencies.
-- **In-memory impls** of every trait in `canon-core` — the test harness.
-- **Outbox processor**: drains outbox → outbound queue only. No Cassandra, no projections, no external publish.
-- **No direct Cassandra writes** from command handler. Events go to outbox only.
-- **Snapshots by event store consumer**: checks `version % N == 0` after confirmed Cassandra write.
-- **Outbox pattern**: events + command written in single YugabyteDB ACID txn. Outbox is the commit point.
-- **Idempotency**: all event handlers and projections must be safe to call twice.
+- **tokio + async_trait only**. No async-std. No manual `Pin<Box<dyn Future>>`.
+- **`thiserror`** per crate. No `anyhow`. No god enum.
+- **`AggregateId(Uuid)`** newtype. Never plain `Uuid`.
+- **Proc-macros** in the crate that owns the concept. No `canon-macros` umbrella.
+- **In-memory impls** for every trait — the test harness lives in `canon-core`.
+- **Outbox pattern**: events + command in one YugabyteDB ACID txn. Outbox is the commit point.
+- **Outbox processor** drains outbox → outbound queue. Nothing else.
+- **No direct Cassandra writes** from command path.
+- **Snapshots** are written by the event store consumer when `version % N == 0`.
+- **Idempotency**: every event handler and projection must be safe to call twice.
 - **Optimistic concurrency**: event store rejects version mismatches.
-- **Macro-driven traits**: users never implement `Aggregate`, `CommandHandler`, `EventHandler`, or `Projection` directly — macros generate all impls.
-- **Exhaustiveness**: every `#[command(X, version = N)]` needs `#[command_handler(X, version = N)]`. Every `#[event(X, version = N)]` needs `#[event_combiner(X, version = N)]`. Missing = compile error.
-- **Event handlers are aggregate-agnostic**: `#[event_handler]` has no aggregate type parameter.
-- **No casting**: no upcasting or downcasting. Version-matched routing reads `event_version`/`command_version` and dispatches to the handler at that exact version.
-- **`window_ttl` requires `oversight`**: compile error without it.
-- **Window key is `(handler_id, correlation_key)`**: resolved from handler's `correlate`
-  fn or fallback to envelope `correlation_id`. Never `aggregate_id`.
-- **Auto-registration via `inventory`**: macros emit static registrations. `ServiceBuilder` discovers everything automatically.
-- **READMEs in every crate**: the root README and each crate's own README must be kept up to date. When a PR adds or changes a crate's public API, traits, or modules, update that crate's README to reflect the change.
-- **No local simulation in the frontend**: the demo exists to showcase Canon's event sourcing pipeline. Every state change in the UI (ship movement, stock levels, oversight gates, event log entries) must be driven by real events flowing through the Canon pipeline (command → outbox → Kafka → event store → WebSocket). The frontend must never fake events with local timers, hardcoded event chains, or fire-and-forget POST fallbacks. If the gateway is down, show a connection error — do not mask the failure with a local simulation.
-- **Per-service storage isolation**: each demo service MUST use its own YugabyteDB schema (`canon_fleet`, `canon_cargo`, etc.) and Cassandra keyspace. Services must never share outbox, commands, inbox, or event store tables. Use `canon_demo_shared::db::create_service_pool()` for YugabyteDB and `CassandraEventStore::new_with_keyspace()` for Cassandra. The gateway uses per-service pools via `AppState::pool_for_service()`.
-- **`rskafka` only for Kafka**. No `rdkafka`. No C dependencies in Kafka crates. All Kafka crates must be pure Rust and cross-compilable. Consumer offset management is in-memory with restart-from-zero -- application-layer idempotency is the safety net.
-- **No hand-wired event routing in services**. Cross-service and internal event routing is a framework responsibility. Services declare external topic subscriptions via `ServiceBuilder` and write `#[event_handler]` impls. No manual Kafka consumers, no hand-built `CommandEnvelope` construction, no raw SQL inbox writes, no bespoke `cross_service.rs` modules. The framework's adaptor, inbox, and dispatcher handle all routing, deduplication, windowing, and dispatch.
-- **No interactive UI before `ready=true`**: buttons, click handlers, and user-facing actions must be disabled until the game projection returns `ready: true`. The bootstrap takes 3-8 seconds; during that window, `state.ships` is empty and commands silently fail. Disable all action buttons when there is no ship in the state.
-- **No silent early returns in command functions**: every `return` in `depart_ship`, `load_cargo`, `deliver_cargo` must either set `pending_command`, set `command_error`, or log to the browser console. A click that does nothing with no feedback is a bug.
+- **Macros generate all impls**. Users never hand-write `Aggregate`/`CommandHandler`/`EventHandler`/`Projection`.
+- **Exhaustiveness** (compile errors): `#[command(X,v=N)]` ↔ `#[command_handler(X,v=N)]`; `#[event(X,v=N)]` ↔ `#[event_combiner(X,v=N)]`.
+- **Version-matched routing, no casting**: framework reads `event_version`/`command_version` and dispatches to the exact matching handler.
+- **Event handlers are aggregate-agnostic** — `#[event_handler]` has no aggregate type parameter.
+- **`window_ttl` requires `oversight`** (compile error otherwise).
+- **Window key = `(handler_id, correlation_key)`** — from `correlate` fn or fallback to envelope `correlation_id`. Never `aggregate_id`.
+- **Auto-registration via `inventory`**. `ServiceBuilder` discovers everything.
+- **No hand-wired event routing in services**. No manual Kafka consumers, no hand-built `CommandEnvelope`s, no raw inbox SQL, no `cross_service.rs`. Use `#[event_handler]` + `ServiceBuilder` topic subscriptions.
+- **Per-service storage isolation**: each demo service owns its YugabyteDB schema (`canon_{fleet,cargo,navigation,supply,station}`) and Cassandra keyspace. Never share inbox/outbox/commands/events tables. Use `canon_demo_shared::db::create_service_pool()` and `CassandraEventStore::new_with_keyspace()`.
+- **`rskafka` only**. No `rdkafka`, no C deps. Pure Rust, cross-compilable. Offsets in-memory, restart from zero — application-layer idempotency is the safety net.
+- **READMEs stay current**. Touch a crate's public API → update its README in the same PR.
 
 ---
 
-## Workspace layout & dependency graph
+## Core types
 
-```
-canon-core                              ← traits, types, in-memory impls, proc-macros
-    └── canon-core-macros               ← proc-macro = true subcrate, re-exported from canon-core
-    ├── canon-event-store               → canon-event-store-cassandra
-    ├── canon-command-store             → canon-command-store-yugabyte
-    ├── canon-snapshot-store            → canon-snapshot-store-yugabyte
-    ├── canon-inbox                     → canon-inbox-yugabyte
-    ├── canon-inbound-queue             → canon-inbound-queue-kafka
-    ├── canon-outbound-queue            → canon-outbound-queue-kafka
-    ├── canon-projection-store          → canon-projection-store-yugabyte
-    ├── canon-publisher                 → canon-publisher-kafka
-    ├── canon-adaptor                   → canon-adaptor-kafka
-    └── canon-deadletter                → canon-deadletter-yugabyte
-canon-test                              ← integration tests, in-memory only
-canon-demo/                             ← shared/, fleet-service/, cargo-service/,
-                                          navigation-service/, supply-service/,
-                                          station-service/, gateway/, frontend/
-canon-site/                             ← landing page (static HTML/CSS)
-    └── reference/site-mockup.html      ← visual reference for landing page
-canon-docs/                             ← mdBook documentation source + themed output
-```
+Defined in `canon-core/src/`. Treat as frozen contracts:
 
----
+`AggregateId(Uuid)` · `Version(u64)` · `EventEnvelope` · `CommandEnvelope` · `IncomingMessage { Command | InternalEvent | ExternalEvent }` · `Oversight { Ready | NotReady | Discard }` · `CounterfactualRequest`/`Result`/`CommandDiff`.
 
-## Implementation phases
+## Core traits
 
-Work strictly in order. Each phase must compile and pass tests before the next begins.
+Defined in `canon-core/src/`. Do not modify signatures.
 
-1. **Workspace scaffolding** — `Cargo.toml` per crate, empty `lib.rs` files. `cargo check --workspace` passes.
-2. **canon-core types** — `AggregateId`, `Version`, `EventEnvelope`, `CommandEnvelope`, `IncomingMessage`, `Oversight`, counterfactual types.
-3. **canon-core traits** — `Aggregate` (no `handle`/`apply`), `CommandHandler`, `EventHandler`, `EventCombiner`, `Projection`, `ProjectionHandler`, `CounterfactualReplay`.
-3b. **canon-core proc-macros** — all eight macros in `canon-core/canon-core-macros/` subcrate (re-exported from `canon-core`): `#[aggregate]` → `#[command]` + `#[event]` → `#[event_combiner]` → `#[command_handler]` → `#[event_handler]` → `#[projection]` → `#[projection_handler]`.
-4. **In-memory implementations** — all 10 in `canon-core/src/memory/`, must work with macro-generated dispatch.
-5. **canon-test** — `TestHarness` wiring all in-memory impls. Test modules: snapshotting, oversight, counterfactual replay, dead lettering, projection rebuild, inbox window expiry, idempotency, outbound fan-out.
-6. **Trait crates** — thin crates, trait + associated types only, re-export from `canon-core`.
-7. **Infrastructure crates** — in order: inbox-yugabyte, inbound-queue-kafka, outbound-queue-kafka, command-store-yugabyte, snapshot-store-yugabyte, event-store-cassandra, projection-store-yugabyte, deadletter-yugabyte, publisher-kafka, adaptor-kafka.
-8. **canon-demo shared** — domain types, events, commands, topic constants. No logic.
-9. **fleet-service** — reference implementation using all framework features.
-10. **Remaining services** — navigation, cargo, station, supply.
-11. **Gateway** — axum REST + WebSocket.
-12. **Frontend** — Leptos WASM.
+`Aggregate` (hydrate dispatches to version-matched combiners; `type State = Self`) · `CommandHandler<A>` (one per command/version, returns single event or Err) · `EventHandler` (no aggregate param, optional `oversight`/`correlate`) · `Projection` (idempotent apply + rebuild) · `EventCombiner<A>` (sync state fold, generated) · `ProjectionHandler<P>` (generated) · `CounterfactualReplay`.
+
+## Macros
+
+All in `canon-core/canon-core-macros/`, re-exported from `canon-core`. Eight macros:
+
+`#[aggregate(snapshot_every = N)]` — generates `impl Aggregate`, hydration dispatch, `Default`, serde, `inventory` reg.
+`#[command(Aggregate, version = N, produces = [Event])]` — `produces` is metadata only; one event or Err.
+`#[event(Aggregate, version = N)]` — versions coexist as distinct types.
+`#[event_combiner(Aggregate, version = N)]` — sync, pure fold.
+`#[command_handler(Aggregate, version = N)]` — return type must match `produces`.
+`#[event_handler(window_ttl = "..."?)]` with `#[handles(EventType, version = N)]` per method.
+`#[projection]` / `#[projection_handler(ProjectionName)]`.
+
+`ServiceBuilder::new().for_aggregate::<Ship>().build()` — discovers everything via `inventory`.
+
+For full signatures and examples: read the macros crate and `canon-test/`.
 
 ---
 
-## Core types (do not modify)
+## Operational details (framework responsibilities)
 
-```rust
-pub struct AggregateId(uuid::Uuid);  // new(), from_uuid(), as_uuid()
-pub struct Version(u64);              // initial() → 0, next() → +1, as_u64()
+**Dispatcher**: polls inbox. Command path → hydrate → version-matched handler → ACID txn (commands + outbox). Event-handler path → ready window → call `handle()` → if `Some(CommandEnvelope)` returned, write to inbox via `InboxPort`.
 
-pub struct EventEnvelope {
-    pub event_id: Uuid, pub aggregate_id: AggregateId, pub version: Version,
-    pub event_type: String, pub event_version: u32, pub payload: Bytes,
-    pub correlation_id: Uuid, pub causation_id: Uuid, pub timestamp: DateTime<Utc>,
-}
+**Cross-service + internal event routing**: adaptor (external) or 4th outbound consumer (internal) checks `EventHandlerRegistration` inventory for matching `#[handles]`, calls `Inbox::submit`. Inbox dedups, accumulates per `(handler_id, correlation_key)`, evaluates oversight. Service authors only write `#[event_handler]`.
 
-pub struct CommandEnvelope {
-    pub command_id: Uuid, pub aggregate_id: AggregateId,
-    pub correlation_id: Uuid, pub causation_id: Uuid, pub timestamp: DateTime<Utc>,
-    pub payload: Bytes, pub command_version: u32,
-}
+**Outbox processor**: `SELECT … FOR UPDATE SKIP LOCKED` → publish → `delivered_at`. Bounded channel (default 1024).
 
-pub enum IncomingMessage { Command(CommandEnvelope), InternalEvent(EventEnvelope), ExternalEvent(EventEnvelope) }
-pub enum Oversight { Ready, NotReady, Discard }
+**Service lifecycle**: `ServiceBuilder::build()` → `Service`. `service.start()` spawns 5 background tasks (outbox, event store, projection, publisher, internal-event consumer) with watch-channel shutdown.
 
-pub struct CounterfactualRequest { pub aggregate_id: AggregateId, pub branch_version: Version, pub substituted_command: CommandEnvelope }
-pub struct CounterfactualResult { pub original_commands: Vec<CommandEnvelope>, pub counterfactual_commands: Vec<CommandEnvelope>, pub diff: CommandDiff }
-pub struct CommandDiff { pub added: Vec<CommandEnvelope>, pub removed: Vec<CommandEnvelope>, pub unchanged: Vec<CommandEnvelope> }
-```
+**Outbound consumers** (4): event store (Cassandra + snapshot at `version % N == 0`, retry 3 → DLQ) · projections (idempotent apply, `last_version`, rebuild via offset reset) · publisher (`canon.{service}.events`) · internal-event re-entry. All restart from offset 0; rely on downstream idempotency.
 
----
+**Kafka pattern (rskafka)**: `ClientBuilder::new(brokers).build().await` → `client.partition_client(topic, 0, UnknownTopicHandling::Retry)`. Produce: `produce(vec![record], Compression::NoCompression)`. Consume: `fetch_records(offset, 1..1_048_576, timeout_ms)` polled, `Mutex<i64>` offset. No consumer groups. Commit = no-op. Errors: per-crate `thiserror`.
 
-## Core traits (do not modify)
+**Inbox**: idempotent on `(handler_id, message_id)`. `processed_windows(window_id)` for batch idempotency. Window TTL → `expired` → DLQ with `window_expired`.
 
-```rust
-// Aggregate — hydrate dispatches to version-matched #[event_combiner] impls
-pub trait Aggregate: Sized + Send + Sync + 'static {
-    type State: Default + Send + Sync;
-    type Error: std::error::Error + Send + Sync + 'static;
-    fn hydrate(state: &mut Self::State, events: impl Iterator<Item = EventEnvelope>) -> Result<(), Self::Error>;
-}
+**InboxPort**: local re-entry only. Cross-service = REST or framework Kafka routing.
 
-// CommandHandler — one per command type per version
-pub trait CommandHandler<A: Aggregate>: Send + Sync + 'static {
-    type Command: Send + Sync;
-    type Event: Send + Sync;
-    type Error: std::error::Error + Send + Sync + 'static;
-    async fn handle(&self, state: &A::State, command: Self::Command) -> Result<Self::Event, Self::Error>;
-}
+**Counterfactual replay**: operates on commands, not events. Hydrates to branch, routes stored commands by `command_version`, diffs at command level. `ReplayEventStore` points at read replica.
 
-// EventHandler — no aggregate parameter, optional oversight + correlate
-pub trait EventHandler: Send + Sync + 'static {
-    type Event: Send + Sync;
-    type Error: std::error::Error + Send + Sync + 'static;
-    async fn handle(&self, events: Vec<Self::Event>) -> Result<Option<CommandEnvelope>, Self::Error>;
-    fn oversight(&self, accumulated: &[IncomingMessage]) -> Oversight { Oversight::Ready }
-    fn correlate(&self, message: &IncomingMessage) -> Uuid { message.correlation_id() }
-}
+**Projection rebuild**: `rebuilding=true` → reads fall back to read-through → reset consumer offset → replay → `rebuilding=false`.
 
-// Projection — read model, idempotent apply
-pub trait Projection: Send + Sync + 'static {
-    type Event: Send + Sync;
-    type Store: ProjectionStore;
-    type Error: std::error::Error + Send + Sync + 'static;
-    async fn apply(&self, event: &Self::Event, store: &Self::Store) -> Result<(), Self::Error>;
-    async fn rebuild(&self, events: impl Stream<Item = Self::Event> + Send, store: &Self::Store) -> Result<(), Self::Error>;
-    fn projection_id(&self) -> &str;
-}
-
-// EventCombiner — synchronous state folding, one per event per version
-// Generated by #[event_combiner]. Used internally by Aggregate::hydrate() dispatch.
-pub trait EventCombiner<A>: Send + Sync + 'static {
-    fn combine(&self, state: &mut A);
-}
-
-// ProjectionHandler — applies one event type to a projection's read model
-// Generated by #[projection_handler]. Used internally by projection dispatch.
-pub trait ProjectionHandler<P>: Send + Sync + 'static {
-    type Event: Send + Sync;
-    fn apply(&self, event: &Self::Event, store: &mut P);
-}
-
-// CounterfactualReplay
-pub trait CounterfactualReplay: Send + Sync {
-    type Error: std::error::Error + Send + Sync + 'static;
-    async fn replay(&self, request: CounterfactualRequest) -> Result<CounterfactualResult, Self::Error>;
-}
-```
-
----
-
-## Macro surface (do not modify)
-
-Users never implement traits directly. Macros generate all impls and emit `inventory` registrations. Version-matched routing: framework reads `event_version`/`command_version` from stored envelopes, dispatches to handler registered at that exact version. No casting.
-
-### `#[aggregate(snapshot_every = N)]`
-
-```rust
-#[aggregate(snapshot_every = 50)]
-pub struct Ship { status: ShipStatus, fuel_level: f32 }
-```
-Generates: `impl Aggregate` with `type State = Self` (aggregate struct is its own state — opinionated), version-matched hydration dispatch, `Default`, serde derives, `inventory` registration.
-
-### `#[command(Aggregate, version = N, produces = [Events...])]`
-
-```rust
-#[command(Ship, version = 1, produces = [ShipDeparted])]
-pub struct DepartForStation { pub destination: StationId }
-```
-`version` defaults to 1. `produces` is declarative metadata only — no type is generated. It documents which event the handler returns and is used for macro wiring and schema registry. Must have matching `#[command_handler]`.
-
-### `#[event(Aggregate, version = N)]`
-
-```rust
-#[event(Ship, version = 1)]
-pub struct ShipDeparted { pub destination: StationId }
-
-#[event(Ship, version = 2)]  // v2 coexists as a different type
-pub struct ShipDeparted { pub destination: StationId, pub fuel_at_departure: f32 }
-```
-`version` defaults to 1. Must have matching `#[event_combiner]` at same version.
-
-### `#[event_combiner(Aggregate, version = N)]`
-
-Synchronous, pure state folding. One per event per version.
-
-```rust
-#[event_combiner(Ship, version = 1)]
-impl ShipDeparted {
-    fn combine(&self, state: &mut Ship) { state.status = ShipStatus::InFlight; }
-}
-```
-
-### `#[command_handler(Aggregate, version = N)]`
-
-Returns `Result<EventType, Error>` — the single event type declared in `produces`. A command produces exactly one event or returns `Err`. Rejection is `Err`, not a separate event type. During counterfactual replay, `command_version` routes to the matching handler.
-
-```rust
-#[command_handler(Ship, version = 1)]
-impl DepartForStationHandler {
-    type Error = FleetError;
-    fn handle(&self, state: &Ship, cmd: DepartForStation) -> Result<ShipDeparted, FleetError> {
-        if state.status != ShipStatus::Docked { return Err(FleetError::ShipNotDocked); }
-        Ok(ShipDeparted { destination: cmd.destination })
-    }
-}
-```
-
-### `#[event_handler]`
-
-No aggregate parameter. `#[handles]` declares event type + version. `window_ttl` requires `oversight` (compile error without). Event handlers work for both internal events (this service's own events) and external events (from other services via adaptor). The framework routes matching events to the inbox, handles dedup/windowing/oversight, and calls `handle()` when the window is ready. The service author just writes the handler — no manual Kafka consumers or inbox writes.
-
-```rust
-#[event_handler(window_ttl = "30m")]
-impl CargoUnloadingHandler {
-    #[handles(CargoEvent, version = 1)]
-    fn handle(&self, events: Vec<CargoEvent>) -> Option<CommandEnvelope> { ... }
-
-    // Optional — extracts domain correlation key. Falls back to envelope correlation_id.
-    fn correlate(&self, message: &IncomingMessage) -> Uuid { ... }
-
-    // Required when window_ttl is set. Returns Ready/NotReady/Discard.
-    fn oversight(&self, accumulated: &[IncomingMessage]) -> Oversight { ... }
-}
-```
-
-### `#[projection]` / `#[projection_handler(ProjectionName)]`
-
-```rust
-#[projection]
-pub struct StationInventory { pub station_id: StationId, pub stock_levels: HashMap<CargoType, u32> }
-
-#[projection_handler(StationInventory)]
-impl CargoReceivedHandler {
-    fn apply(&self, event: &CargoReceived, store: &mut StationInventory) {
-        *store.stock_levels.entry(event.cargo_type).or_insert(0) += event.quantity;
-    }
-}
-```
-
-### Compile-time enforcement
-
-- `#[command(X, v=N)]` → requires `#[command_handler(X, v=N)]` — compile error if missing
-- `#[event(X, v=N)]` → requires `#[event_combiner(X, v=N)]` — compile error if missing
-- `#[event_handler]`, `#[projection_handler]` — optional (warning for unhandled new event versions)
-- `window_ttl` without `oversight` → compile error
-- `correlate` is optional — no enforcement, fallback to envelope `correlation_id` is always safe
-- `#[command_handler]` return type must be the single type named in `produces` — compile error if mismatched
-
-Enforcement via marker traits. `ServiceBuilder` auto-discovers via `inventory`:
-
-```rust
-ServiceBuilder::new().for_aggregate::<Ship>().build()
-```
-
----
-
-## Operational details
-
-### Dispatcher
-The dispatcher is the central routing component. It polls the inbox and handles two
-kinds of messages:
-
-**Command path**: poll inbox for unprocessed commands → hydrate aggregate state →
-call version-matched `#[command_handler]` → single YugabyteDB ACID txn: `INSERT INTO
-commands (...)` + `INSERT INTO outbox (...) x N`. One command always has exactly one
-handler.
-
-**Event handler path**: poll inbox for ready windows → call `EventHandler::handle(events)`
-→ if it returns `Some(CommandEnvelope)`, write that command back to the inbox via
-`InboxPort`. Most event handlers handle a single event with no windowing (oversight
-defaults to `Ready`, so the window is immediately dispatchable). Handlers with
-`window_ttl` accumulate multiple events and wait for oversight to return `Ready`.
-
-Both paths are framework responsibilities. Service authors only write `#[command_handler]`
-and `#[event_handler]` impls — they never interact with the inbox, dispatcher, or outbox
-directly.
-
-### Cross-service event routing
-Cross-service event consumption is a framework responsibility. The service author declares
-which external Kafka topics to subscribe to (via `ServiceBuilder`) and writes
-`#[event_handler]` impls for the events they care about. The framework does the rest:
-
-1. `canon-adaptor-kafka` subscribes to the declared external topics
-2. When an event arrives, the framework checks `EventHandlerRegistration` inventory for
-   all handlers that `#[handles]` that event type/version
-3. For each matching handler, calls `Inbox::submit(handler_id, event_id, ExternalEvent(envelope))`
-4. The inbox deduplicates, accumulates into the handler's window, evaluates oversight
-5. When the window is `Ready`, the dispatcher polls it and calls `EventHandler::handle()`
-6. If the handler returns `Some(CommandEnvelope)`, it re-enters the inbox for command dispatch
-
-Internal events (service reacting to its own events) follow the identical path — the only
-difference is the source: the 4th outbound consumer writes `InternalEvent` to the inbox
-instead of the adaptor writing `ExternalEvent`. From the inbox onwards, the flow is the same.
-
-**Services must never hand-wire Kafka consumers for cross-service or internal event routing.**
-No manual `CommandEnvelope` construction, no raw SQL inbox writes, no bespoke `cross_service.rs`
-modules. All event routing goes through `#[event_handler]` + the framework's inbox/dispatcher.
-
-### Outbox processor
-Background tokio task. `SELECT ... FOR UPDATE SKIP LOCKED` → publish to outbound queue → set `delivered_at`. Backpressure via bounded channel (default 1024).
-
-### Service lifecycle
-`ServiceBuilder::build()` creates a `Service`. Call `service.start()` to spawn all
-background tasks: outbox processor, event store consumer, projection consumer, publisher
-consumer, internal event consumer. Each runs as a `tokio::spawn` task with graceful
-shutdown via watch channel. The `ConsumerReceiver` trait provides the polling interface
-for consumers to receive events from the outbound queue.
-
-### Outbound queue consumers (4 independent groups)
-- **Event store**: writes to Cassandra. Snapshot if `version % N == 0`. Retry up to 3 on conflict → dead letter.
-- **Projection**: applies to read models. Updates `last_version`. Rebuilds via Kafka offset reset while `rebuilding = true`.
-- **Publisher**: publishes to `canon.{service}.events` for other services.
-- **Internal event consumer**: routes a service's own events back to the inbox for event handler dispatch. For each event, checks `EventHandlerRegistration` inventory for matching `#[handles]` declarations. For each match, calls `Inbox::submit(handler_id, event_id, InternalEvent(envelope))`. The inbox handles dedup, windowing, and oversight from there.
-
-All consumers restart from offset 0 and rely on downstream idempotency to skip already-processed events. No Kafka-side offset commit.
-
-### Kafka crate patterns (rskafka)
-
-All four Kafka crates (`canon-inbound-queue-kafka`, `canon-outbound-queue-kafka`,
-`canon-publisher-kafka`, `canon-adaptor-kafka`) use `rskafka` with a consistent pattern:
-
-- **Connection**: `ClientBuilder::new(broker_list).build().await` then
-  `client.partition_client(topic, 0, UnknownTopicHandling::Retry)` to get a `PartitionClient`.
-- **Produce**: `partition_client.produce(vec![record], Compression::NoCompression)` with
-  `Record { key, value, headers: BTreeMap::new(), timestamp }`.
-- **Consume**: `partition_client.fetch_records(next_offset, 1..1_048_576, timeout_ms)` in a
-  polling loop. Offset tracked in-memory (`Mutex<i64>`, starts at 0).
-- **Commit**: Always a no-op. Application-layer idempotency (inbox dedup, Cassandra PK,
-  projection checkpoint) handles duplicates on restart.
-- **No consumer groups**: rskafka has no consumer group abstraction. Each consumer polls
-  partition 0 independently. `group_id` fields are kept for API compatibility but unused.
-- **Errors**: each crate defines its own `thiserror` error type wrapping rskafka errors as strings.
-
-### Inbox
-- Idempotent intake via `handler_id + message_id` composite key
-- Window key is `(handler_id, correlation_key)` — from handler's `correlate` fn or fallback to envelope `correlation_id`
-- Each unique correlation key is an independent window — a handler may have many concurrent in-flight windows
-- Oversight controls dispatch readiness (`Ready`/`NotReady`/`Discard`)
-- `window_id` travels with batch → `processed_windows` table for batch idempotency
-- Window expiry: TTL → `expired` status → dead letter with reason `window_expired`
-
-### InboxPort
-Local re-entry only. Event handlers submit `CommandEnvelope` to local inbox. Cross-service = REST only.
-
-### Counterfactual replay
-Operates on commands not events. Hydrates state to branch point (version-matched combiners), routes stored commands via `command_version` to matching handler, diffs at command level. `ReplayEventStore` port points at read replica.
-
-### Projection rebuild
-Set `rebuilding = true` → read endpoints fall back to read-through → reset consumer offset → Kafka replays → set `rebuilding = false`.
-
-### Dead letter handling
-Retry count in `retry_attempts` table (crash-safe). Max failures → dead letter store. Requeue via admin API re-enters inbox with fresh `expires_at`.
+**Dead letters**: `retry_attempts` table (crash-safe). Max → `dead_letters`. Admin requeue re-enters inbox with fresh `expires_at`.
 
 ---
 
 ## Schemas
 
-### YugabyteDB tables (see init-schema scripts for full DDL)
+Per-service YugabyteDB schemas (`canon_{fleet,cargo,navigation,supply,station}`) and Cassandra keyspaces (same names). Tables per schema: `inbox_messages`, `inbox_windows`, `processed_windows`, `commands`, `outbox` (+ `outbox_seq`), `snapshots`, `projection_checkpoints`, `dead_letters`, `retry_attempts`. Cassandra: `events(aggregate_id UUID, version BIGINT, …, PK (aggregate_id, version))`.
 
-Each service uses its own schema (`canon_fleet`, `canon_cargo`, `canon_navigation`, `canon_supply`, `canon_station`). All tables below exist in each schema:
-
-```sql
--- inbox: inbox_messages(handler_id, message_id), inbox_windows(handler_id, correlation_key), processed_windows(window_id)
--- commands: commands(command_id), idx: (aggregate_id, created_at)
--- outbox: outbox(id), sequence outbox_seq, idx: (sequence_number) WHERE delivered_at IS NULL
--- other: snapshots(aggregate_id), projection_checkpoints(projection_id), dead_letters(id), retry_attempts(message_id)
-```
-
-### Cassandra
-
-Each service uses its own keyspace (`canon_fleet`, `canon_cargo`, `canon_navigation`, `canon_supply`, `canon_station`):
-
-```cql
-CREATE TABLE canon_fleet.events (aggregate_id UUID, version BIGINT, ..., PRIMARY KEY (aggregate_id, version)) WITH CLUSTERING ORDER BY (version ASC);
-```
-
-### Environment variables
-
-```
-CASSANDRA_NODES=cassandra:9042
-YUGABYTE_URL=postgres://canon:canon@yugabytedb:5433/canon
-KAFKA_BROKERS=kafka:9092
-```
-
----
-
-## Deployment
-
-All demo infrastructure runs on Kubernetes via minikube (local) or GKE (production).
-
-### Prerequisites (one-time setup for local development)
-
-```bash
-rustup target add aarch64-unknown-linux-musl
-brew install filosottile/musl-cross/musl-cross   # provides aarch64-linux-musl-gcc
-```
-
-### Build pipeline
-
-Backend services are cross-compiled locally from macOS to Linux (musl), producing
-static binaries. Each service has a slim alpine Dockerfile that just COPYs the
-pre-built binary. No Rust compilation happens inside Docker.
-
-```
-cargo build --release --target aarch64-unknown-linux-musl   # ~2 min
-docker build (alpine + COPY binary)                          # ~2s each
-minikube image load                                          # ~5s each
-```
-
-The frontend still builds inside Docker (WASM/Trunk). `init-schema` is unchanged.
-
-```
-canon-demo/k8s/
-  base/                  # shared manifests (namespace, infra, jobs, services)
-  overlays/
-    minikube/            # imagePullPolicy: Never, local images
-    gke/                 # placeholder for production (Ingress, HPA, Artifact Registry)
-```
-
-```bash
-cd canon-demo && make k8s-up
-# or manually:
-minikube start --cpus=4 --memory=8g
-make k8s-build    # cross-compile + docker build + minikube image load
-kubectl apply -k k8s/overlays/minikube/
-minikube tunnel   # access frontend at localhost:80
-```
-
-All pods run in a single `canon` namespace. Infrastructure (YugabyteDB, Cassandra,
-Zookeeper, Kafka) run as StatefulSets with PVCs. Init Jobs create schemas, keyspaces,
-and all 15 Kafka topics before services start. The 5 Canon services are background
-processors with no exposed ports — only gateway (8080) and frontend (80) have Services.
-
-See `canon-demo/Makefile` for all `k8s-*` targets (`k8s-up`, `k8s-down`, `k8s-build`,
-`k8s-deploy`, `k8s-status`, `k8s-logs`, `k8s-tunnel`, `k8s-restart`, `k8s-clean`,
-`k8s-test-e2e`).
-
-### Game bootstrap
-
-The gateway automatically bootstraps the demo game state on startup:
-- Registers 4 stations (Alpha Depot 5000kg, Beta Relay 3000kg, Gamma Outpost
-  2000kg, Delta Prime 4000kg) if not already registered
-- Seeds initial stock via `RecordCargoReceived` (Alpha 85%, Beta 60%, Gamma 40%,
-  Delta 75% of capacity)
-- Registers VSS Meridian ship (5000kg capacity) if not already registered
-- Idempotent — safe on every gateway restart (checks if data already exists before inserting)
-
-The stock drain background task starts after a 15s delay to allow bootstrap
-and pipeline processing to complete.
-
-### GKE (production)
-
-The demo runs on GKE at `https://canon.mopjones.com`.
-
-**Access:**
-- Frontend: `https://canon.mopjones.com`
-- API: `https://canon.mopjones.com/health`, `/fleet/ships`, `/stations`, etc.
-- WebSocket: `wss://canon.mopjones.com/events`
-
-**Authentication (when site is locked down):**
-
-The gateway has an optional auth gate (`CANON_AUTH_PASSWORD` env). When set, all
-requests require authentication. Two methods:
-
-1. Header: `X-Canon-Auth: <password>` (sets a cookie for subsequent browser requests)
-2. Debug key: `X-Canon-Debug: <key>` (bypasses all auth, for CLI debugging)
-
-Local files (never committed):
-- `~/.canon-debug-key` — debug API key
-- `~/.canon-auth-password` — auth gate password
-
-**CLI usage:**
-```bash
-# Check health:
-curl -H "X-Canon-Debug: $(cat ~/.canon-debug-key)" https://canon.mopjones.com/health
-
-# Run Playwright against live site:
-CANON_AUTH_PASSWORD=$(cat ~/.canon-auth-password) npx playwright test
-```
-
-**Toggle public/private:**
-```bash
-# Lock down (require password):
-kubectl set env deployment/gateway -n canon CANON_AUTH_PASSWORD=<password>
-
-# Go public (remove auth):
-kubectl set env deployment/gateway -n canon CANON_AUTH_PASSWORD-
-```
-
-**Deploy:**
-Merging to `main` automatically deploys via GitHub Actions.
-Manual deploy: `cd canon-demo && make gke-deploy`
-
-**GKE cluster:** `canon-demo` in `europe-west2-a`, 1 preemptible e2-standard-4 node.
-**Image registry:** `europe-west2-docker.pkg.dev/canon-demo-prod/canon/`
-
----
-
-## canon-demo domains
-
-| Service | Aggregate | Commands | Events |
-|---|---|---|---|
-| fleet | Ship | RegisterShip, AssignRoute, DepartForStation, ScheduleResupply, DecommissionShip | ShipRegistered, RouteAssigned, ShipDeparted, ResupplyScheduled, ShipDecommissioned |
-| cargo | Manifest | CreateManifest, LoadCargo, BeginUnloading, RecordUnloaded, CloseManifest | ManifestCreated, CargoLoaded, UnloadingStarted, CargoUnloaded, ManifestClosed |
-| navigation | Route | PlanRoute, RecordDeparture, UpdatePosition, RecordArrival | RoutePlanned, ShipDeparted, PositionUpdated, ShipArrivedAtStation |
-| supply | Inventory | RecordStock, RequestResupply, DispatchResupply, ConfirmDelivery | StockRecorded, ResupplyRequested, ResupplyDispatched, DeliveryConfirmed |
-| station | Station | RegisterStation, RecordDocking, RecordCargoReceived, UpdateCapacity, DrainStock | StationRegistered, ShipDocked, CargoReceived, StationStockLow, CapacityUpdated, StockDrained |
-
-### Cross-service flows
-`Fleet:ShipDeparted → Navigation` · `Navigation:ShipArrivedAtStation → Cargo, Station` · `Station:StationStockLow → Supply` · `Supply:ResupplyDispatched → Fleet`
-
-### Kafka topics (15 total — all explicitly created, no auto-create)
-- **Inbound** (adaptor → inbox → dispatcher): `canon.fleet.inbound` · `canon.cargo.inbound` · `canon.navigation.inbound` · `canon.supply.inbound` · `canon.station.inbound`
-- **Outbound** (outbox processor → 3 consumer groups): `canon.fleet.outbound` · `canon.cargo.outbound` · `canon.navigation.outbound` · `canon.supply.outbound` · `canon.station.outbound`
-- **Published events** (cross-service): `canon.fleet.events` · `canon.cargo.events` · `canon.navigation.events` · `canon.supply.events` · `canon.station.events`
-
-### Gateway (axum)
-POST: `/fleet/ships`, `/fleet/ships/:id/route`, `/fleet/ships/:id/depart`, `/cargo/manifests`, `/cargo/manifests/:id/load`, `/navigation/routes`, `/supply/resupply`, `/stations/:id/register`
-GET: `/stations/:id/inventory` (read-ready), `/ships/:id/history` (read-through), `/cargo/manifests/:id` (read-through), `/replay/counterfactual`
-WS: `/events` — broadcast all DemoEvent as JSON
-
-### Frontend (Leptos WASM)
-
-The frontend is a Leptos 0.7 CSR WASM application built with Trunk at
-`canon-demo/frontend/`. Two visual references govern the UI:
-
-- **Demo app** (`canon-demo/frontend/reference/mockup.html`): source of truth for the
-  game UI at `/demo` — Live Fleet page, Scenarios page, all game interactions.
-- **Landing page** (`canon-site/reference/site-mockup.html`): source of truth for the
-  framework info site at `/` — hero, pipeline, code showcase, features, footer.
-
-Open the relevant mockup in a browser before writing any code for that section.
-
-- **The mockup is correct**: if the app differs from its mockup, the app is wrong.
-  Extract CSS variables, colours, fonts, spacing, layout, interactions, and text casing
-  from the mockup.
-- **Do not mimic** mockup DOM structure or inline JS. Use idiomatic reactive signals and
-  composable components. Observable behaviour must be identical.
-- **Do not "improve" away from the mockup**: do not add, remove, or rearrange UI
-  elements, change text casing, fonts, colours, or spacing. Accessibility/responsive
-  improvements are fine only if they don't change appearance or interaction flow.
-
----
-
-#### Design system
-
-Fonts loaded from Google Fonts in `index.html`:
-- `Inter` (400/500/600/700) — headings, body text, panel titles, nav tabs, labels
-- `JetBrains Mono` (400/600) — all monospace readouts, timestamps, badges, IDs, code
-
-CSS custom properties defined in `style/main.css` (`:root` for dark, `body.light` for light).
-Key variables: `--bg`, `--panel`, `--raised`, `--border`, `--borderhi`, `--cyan`, `--green`,
-`--amber`, `--red`, `--purple`, `--txt`, `--txthi`, `--txtlo`, `--mono`, `--sans`.
-
-All colours via CSS variables. No hardcoded hex. Light mode is the default.
-Theme toggle adds/removes `light` class on `<body>`. Starfield fades to `opacity:0` in light.
-
----
-
-#### Application structure
-
-Two pages, switched via nav tabs **inside the header bar** (no separate nav row):
-
-**Page 1 — Live Fleet** (`/` or default tab)
-One ship (VSS Meridian), user-controlled. Ship only moves when the user commands it.
-Station stock drains over time — the user must load/deliver supplies to keep stations
-alive. Oversight strip appears bottom-of-map during voyages. Event log as a slim
-horizontal strip at the bottom of the page.
-
-**Page 2 — Scenarios** (`/scenarios`)
-Grid of 5 mission cards. Each card opens a full-screen runner with step progress bar,
-narrative text, interactive action area, and dedicated event log. Each mission demonstrates
-one Canon feature with a beautiful, animated WASM visualisation.
-
----
-
-#### Page 1 — Live Fleet layout
-
-Full-width vertical column (no sidebar):
-
-```
-┌──────────────────────────────────────────────────────────┐
-│ HEADER (56px): logo · nav tabs · fleet status dot · toggle│
-├──────────────────────────────────────────────────────────┤
-│ MAP BAR: ship status · destination buttons               │
-├──────────────────────────────────────────────────────────┤
-│                                                          │
-│   CANVAS MAP (flex:1)                                    │
-│                                                          │
-│   Canvas-drawn planets (coloured circles)                │
-│   Canvas-drawn ship (hull + thrust flame)                │
-│   Canvas-drawn route lines, grid, stars                  │
-│   Station labels + stock % below each planet             │
-│                                                          │
-│   [Oversight strip, position:absolute bottom]            │
-│                                                          │
-├──────────────────────────────────────────────────────────┤
-│ STATION CARDS: 4 equal-width cards with stock bars       │
-├──────────────────────────────────────────────────────────┤
-│ SHIP ACTION BAR: contextual button (load/deliver/fly)    │
-├──────────────────────────────────────────────────────────┤
-│ EVENT LOG STRIP: horizontal, max-height 160px, scrollable│
-└──────────────────────────────────────────────────────────┘
-```
-
-All visual details (header, popup, oversight strip, cards, action bar, event log) match
-the mockup exactly. See `reference/mockup.html`.
-
-**Station positions** (% of canvas):
-- Alpha Depot: 18% 26% — green planet (radius 32)
-- Beta Relay: 68% 14% — purple planet (radius 22) with ring
-- Gamma Outpost: 76% 68% — coral/red planet (radius 28)
-- Delta Prime: 24% 74% — blue planet (radius 20)
-
-**Supply chain game constants**: Fixed supply loop Alpha→Beta→Gamma→Delta→Alpha.
-Drain rates per 3s tick: Alpha 0.15 (starts 85%), Beta 0.20 (starts 60%), Gamma 0.25
-(starts 40%), Delta 0.18 (starts 75%). Deliver at correct station → replenish by 35%.
-Station hits 0% → game over.
-
----
-
-#### Page 2 — Scenarios layout
-
-Scenario page layout matches the mockup. Grid of 5 mission cards → full-screen runner
-modal with step progress bar, narrative section, action area, and event log.
-
----
-
-#### Scenario visualisations (WASM — must be beautiful and animated)
-
-Each scenario has a central interactive visualisation. Must be polished, animated, and clear.
-
-**Mission 01 — The Stranded Cargo (Oversight Gates)**
-Gate card with two requirement rows. User clicks trigger → row animates ○→✓, badge flips amber→green. Downstream events fire.
-
-**Mission 02 — The Ghost Ship (Snapshotting)**
-Hydration counter 0→247 (fast ticking, ~40ms), shows elapsed time. Then snapshot hydration flashes to 247 instantly. Side-by-side bar chart comparison with speedup multiplier ("23x faster hydration").
-
-**Mission 03 — The Resupply Crisis (Cross-service cascade)**
-Vertical pipeline of 5 service nodes lighting up in sequence with animated arrows between them. Summary count at end.
-
-**Mission 04 — The Cassandra Incident (Dead letters)**
-Three dead-letter cards with Requeue/Discard buttons. Requeue transitions red→green, discard fades out.
-
-**Mission 05 — The Duplicate Signal (Idempotency)**
-Two identical command envelope cards side-by-side. Trigger deduplicates second card with red X animation. "ON CONFLICT DO NOTHING" note.
-
----
-
-#### Data sources (when connected to real gateway)
-
-Initial hydration on mount:
-```
-GET /ships          → Vec<ShipState>
-GET /stations       → Vec<StationState>
-GET /admin/oversight/windows  → Vec<OversightWindow>
-GET /admin/deadletters        → Vec<DeadLetterEntry>
-```
-
-Live updates via `WS /events` — `WsMessage` tagged enum:
-```rust
-#[serde(tag = "type")]
-pub enum WsMessage {
-    Event(LiveEvent),
-    ShipUpdate(ShipState),
-    StationUpdate(StationState),
-    OversightUpdate(OversightWindow),
-    DeadLetter(DeadLetterEntry),
-    InfraStatus(InfraStatusMsg),
-}
-```
-
-WebSocket reconnects with 2s backoff. In-memory signals are the source of truth for rendering;
-the WebSocket patches them incrementally. **Signals must only change in response to real
-events arriving over the WebSocket or from initial hydration — never from local timers,
-fake event chains, or fire-and-forget POST fallbacks.** If the gateway is unreachable, the
-UI must show a connection error, not simulate events locally.
-
----
-
-#### Build configuration
-
-See `canon-demo/frontend/Cargo.toml` for dependencies. See `canon-demo/frontend/Trunk.toml`.
-
----
-
-#### Acceptance criteria (all must pass before merge)
-
-- [ ] `trunk build --release` produces a working WASM bundle, zero errors
-- [ ] Visual language (colours, fonts, layout proportions) consistent with `reference/mockup.html`
-- [ ] Fonts are Inter (400/500/600/700) + JetBrains Mono (400/600) — no other font families
-- [ ] Ship only moves when the user commands it (click planet or destination button)
-- [ ] Clicking a ship shows popup with correct version/snapshot data
-- [ ] Selecting a destination POSTs a command to the gateway and the ship moves only when the real event arrives via WebSocket
-- [ ] All UI state changes (ship position, stock levels, oversight gates, event log) are driven by real events from the Canon pipeline — zero local simulation
-- [ ] If the gateway is unreachable, the UI shows a connection error — it does not fake events or fall back to local timers
-- [ ] Oversight strip shows live requirement state during each voyage
-- [ ] Correlation highlighting works in event log (using real correlation IDs from the pipeline)
-- [ ] All 5 scenario missions complete without errors
-- [ ] All 5 scenario visualisations are animated as specced
-- [ ] Light/dark theme toggle works, starfield fades in light mode
-- [ ] WebSocket connects to `WS /events` and patches signals on each message
-- [ ] Initial hydration fetches all 4 endpoints on mount
-- [ ] No `unwrap()` or `expect()` outside tests
-- [ ] No hardcoded colours — all via CSS custom properties
-- [ ] `make k8s-up` (or `kubectl apply -k canon-demo/k8s/overlays/minikube/`) deploys the full stack to minikube with zero manual intervention
-- [ ] Gateway starts and responds on port 8080 inside Kubernetes
-- [ ] `make k8s-test-e2e` Playwright smoke tests pass (stations have stock, ship can fly, events flow, scenarios render)
-
----
-
-## Codebase exploration
-
-Always use the LSP tool first when exploring the codebase — go-to-definition, find-references, hover for type info, and workspace symbol search. Fall back to Grep/Glob only when LSP doesn't cover what you need.
-
-### codemap
-
-`codemap` is installed in this repo. Use it to orient yourself before making changes — it tells you the shape of the codebase, what's changed, and which files are high blast-radius hubs.
-
-```bash
-codemap .                  # full repo tree (respects .codemap/config.json)
-codemap --diff             # what's changed vs main — run this before every PR
-codemap --deps .           # dependency flow between modules
-codemap blast-radius .     # risk analysis for current working set
-codemap handoff .          # read the latest handoff artifact from the previous session
-```
-
-**Rules:**
-- Run `codemap --diff` before starting any task so you know what's already in flight.
-- If codemap warns `⚠ <file> is used by N other files`, treat that file as a hub — changes to it affect N consumers. Be conservative.
-- Run `codemap handoff --latest .` at session start to pick up context from the previous agent session.
-- Run `codemap handoff .` before ending a session so the next agent can continue without re-briefing.
-
----
-## Debugging protocol — when the demo is broken
-
-Triage in this exact order. Do NOT skip steps.
-
-1. **Check the API first.** Create a session and poll the game state:
-   ```bash
-   SID=$(curl -s -X POST https://canon.mopjones.com/sessions | python3 -c "import sys,json; print(json.load(sys.stdin)['session_id'])")
-   curl -s "https://canon.mopjones.com/game/$SID" | python3 -m json.tool
-   ```
-   If `ship.status`, `ship.station_id`, `stations[].stock_pct`, and `event_count` are correct → **the bug is in the frontend**. Stop investigating infrastructure.
-
-2. **If the API is wrong**, check which service is failing:
-   ```bash
-   kubectl logs deployment/fleet-service -n canon-prod --tail=20
-   kubectl logs deployment/navigation-service -n canon-prod --tail=20
-   kubectl logs deployment/station-service -n canon-prod --tail=20
-   ```
-   Look for `ERROR`, `command processing failed`, `OffsetOutOfRange`.
-
-3. **If services show `OffsetOutOfRange`**, Kafka lost data. Diagnose first and test any offset-clearing recovery in a disposable environment before touching prod. Never delete Kafka topics on prod.
-
-4. **If the frontend is the problem**, check:
-   - Are buttons disabled/enabled at the right time? (`has_ship`, `is_pending`, `is_disconnected`)
-   - Is `apply_snapshot` returning early because `ready=false`?
-   - Is `depart_ship`/`load_cargo`/`deliver_cargo` silently returning?
-   - Open browser console — are there errors?
-
-5. **Never nuke prod data.** If you need to test destructive operations, use a disposable environment.
-
----
-
-## What to do when stuck
-
-1. Re-read the relevant section of this file.
-2. Check the trait — the signature is the contract.
-3. Check the dependency graph — wrong dependency = wrong approach.
-4. Ask the user — do not invent solutions.
-
-## What never to do
-
-- Do not add unlisted dependencies without asking.
-- Do not change trait signatures.
-- Do not put business logic in infrastructure crates or infrastructure in `canon-core`.
-- Do not use `unwrap()`/`expect()` in library code.
-- Do not use `clone()` to dodge the borrow checker without flagging it.
-- Do not write `// TODO` — implement it or ask.
-- **Never checkout other branches in the main working directory.** Always use git worktrees (`isolation: "worktree"` in Agent tool, or `git worktree add`) for branch work, and create them under `~/worktrees/` rather than alongside the main repo. Checking out branches directly causes dist file conflicts, merge conflicts with agent worktrees, and lost work. The main working directory must always stay on `main`.
-- **Never use `InMemory*` stores in demo service `main.rs`** — always wire real YugabyteDB/Cassandra/Kafka implementations. In-memory stores are for `canon-test` only.
-- **Never use `#[ignore]` for pipeline tests** — use testcontainers instead. Ignored tests rot and silently break.
-- **Never implement pipeline components in isolation without an e2e test** — every new component must be covered by an in-memory e2e test that exercises it as part of the full pipeline.
-- **Never add C dependencies to Kafka crates** — `rdkafka`, `cmake-build`, `librdkafka-sys` are banned. Use `rskafka` only.
-- **Never store Kafka offsets externally for correctness** — application-layer idempotency is the safety net. External offset storage is a performance optimization only, belongs in service wiring, not framework crates.
-- **Never commit secrets, passwords, API keys, or credentials to the repo.** This includes:
-  - GCP service account keys (`.json` key files)
-  - `~/.canon-debug-key`, `~/.canon-auth-password`
-  - Any `CANON_DEBUG_KEY`, `CANON_AUTH_PASSWORD` values
-  - Database passwords (the `canon:canon` default is fine for local dev ConfigMaps, but
-    production secrets must be in K8s Secrets, never in committed YAML)
-  - GitHub tokens, `gcloud` credentials, kubeconfig files
-  If you need to reference a secret value, use an environment variable or K8s Secret ref.
-  If a file contains secrets, add it to `.gitignore`.
-- **Never nuke production data to debug.** Do not truncate tables, delete Kafka topics, or clear offsets on prod as a debugging step. If prod is broken, diagnose first, reproduce in a disposable environment if needed, then apply the smallest safe fix. Data destruction cascades and makes things worse.
-- **Never blame infrastructure before checking the API.** When the UI shows broken state, `curl /game/$SESSION_ID` first. If the API returns correct data, the bug is in the frontend. Do not touch Kafka, YugabyteDB, or Cassandra until you have confirmed the API itself is returning wrong data.
+Full DDL: `canon-demo/init-schema/`. Env: `CASSANDRA_NODES`, `YUGABYTE_URL`, `KAFKA_BROKERS`.
 
 ---
 
 ## Testing strategy
 
-Two tiers of end-to-end tests, both run on every `cargo test` — no `#[ignore]`:
+Three tiers, all run by default — no `#[ignore]`:
 
-**Tier 1 — In-memory e2e (canon-test)**
-Wire all `InMemory*` stores into a real `Service` via `ServiceBuilder`. Submit commands
-through the dispatcher, step through outbox processor and all 3 consumers, assert events
-reach the event store, projections, and publisher. Sub-second execution, no Docker.
-Tests the logic of every component wired together.
+1. **In-memory e2e** (`canon-test`): `InMemory*` stores wired through real `Service`/`ServiceBuilder`. Sub-second, no Docker. Logic coverage of the full pipeline.
+2. **Testcontainers e2e**: real YugabyteDB + Cassandra + Kafka per test module via `testcontainers` crate. Catches SQL/CQL/serialisation/protocol bugs.
+3. **Playwright** (`canon-demo/e2e/`): browser smoke tests against running cluster. `make k8s-test-e2e` after `make k8s-up`, or via `/test-demo`. Local only.
 
-**Tier 2 — Testcontainers e2e (canon-test or separate crate)**
-Uses the `testcontainers` crate to spin up real YugabyteDB, Cassandra, and Kafka per
-test module. Wires real `CassandraEventStore`, `YugabyteSnapshotStore`, `KafkaPublisher`,
-etc. Tests actual SQL, CQL, and Kafka protocol. Catches serialisation bugs, schema
-mismatches, and connection handling that in-memory can't catch. Containers managed
-automatically — no manual Docker Compose.
+**Never `#[ignore]` pipeline tests** — use testcontainers. `#[ignore]` rots silently. Existing ignored tests in infra crates migrate to testcontainers in #251.
 
-**Tier 3 — Playwright e2e (canon-demo/e2e/)**
-Browser-based smoke tests against a running cluster. Verify the full user experience:
-stations have stock, stock drains over time, ship popup works, events appear in the
-log, scenarios render. Run with `make k8s-test-e2e` after `make k8s-up`, or
-automatically as part of `/test-demo`. Local only — not in CI.
+**Never implement a pipeline component without an e2e test exercising it.**
 
-**Playwright DOM stability rules** (Leptos re-renders detach elements):
-- **Never use `page.$()` + `handle.click()`** — the element handle goes stale when Leptos
-  re-renders. Use `page.locator(selector).click()` or `page.click(selector)` instead.
-- **Never use `page.$()` + `handle.evaluate()`** for checking disabled state — use
-  `page.locator(selector + ':not([disabled])').count()` instead.
-- **Always use `.dest-tab` class** for destination buttons (not bare `:has-text("Alpha")`)
-  to avoid matching multiple elements.
-- **Wrap flight clicks in try/catch** in stress tests so failures report instead of crashing.
+---
 
-**Never use `#[ignore]` for new pipeline tests.** If a test needs infrastructure, use
-testcontainers. `#[ignore]` tests rot — they are never run and silently break.
-Existing `#[ignore]` tests in infrastructure crates (e.g., `canon-command-store-yugabyte`,
-`canon-deadletter-yugabyte`) will be migrated to testcontainers in #251.
+## Codebase exploration
+
+Use **LSP first** (go-to-def, find-refs, hover, workspace symbols). Fall back to grep/glob only when LSP can't.
+
+`codemap`:
+```
+codemap --diff             # before every task
+codemap --deps .
+codemap blast-radius .
+codemap handoff .          # at session start/end
+```
+Hub-file warnings = high blast radius. Be conservative.
+
+---
+
+## When stuck
+
+1. Re-read this file.
+2. Check the trait — the signature is the contract.
+3. Check the dependency graph — wrong dep = wrong approach.
+4. Ask the user. Do not invent.
+
+## Never
+
+- Add unlisted dependencies without asking.
+- Change trait signatures.
+- Put business logic in infra crates, or infra in `canon-core`.
+- `unwrap()`/`expect()` in library code.
+- `clone()` to dodge the borrow checker without flagging it.
+- `// TODO` — implement it or ask.
+- Checkout other branches in the main working directory. Use git worktrees under `~/worktrees/`. Main stays on `main`.
+- Use `InMemory*` stores in demo `main.rs` — wire real impls. In-memory is for `canon-test`.
+- Add C deps to Kafka crates (`rdkafka`/`librdkafka-sys` banned).
+- Store Kafka offsets externally for correctness — that's a perf optimisation only.
+- Commit secrets: GCP keys, `~/.canon-debug-key`, `~/.canon-auth-password`, GitHub tokens, kubeconfigs. Use env vars / K8s Secrets.
+- Nuke prod data to debug — diagnose first, reproduce in disposable env, smallest safe fix.
+- Blame infra before checking the API. `curl /game/$SID` first.

--- a/canon-demo/CLAUDE.md
+++ b/canon-demo/CLAUDE.md
@@ -1,0 +1,116 @@
+# canon-demo — Claude Code guide
+
+Demo system showcasing Canon. Framework rules: `../CLAUDE.md`. Frontend: `frontend/CLAUDE.md`.
+
+---
+
+## Domains
+
+| Service | Aggregate | Commands | Events |
+|---|---|---|---|
+| fleet | Ship | RegisterShip, AssignRoute, DepartForStation, ScheduleResupply, DecommissionShip | ShipRegistered, RouteAssigned, ShipDeparted, ResupplyScheduled, ShipDecommissioned |
+| cargo | Manifest | CreateManifest, LoadCargo, BeginUnloading, RecordUnloaded, CloseManifest | ManifestCreated, CargoLoaded, UnloadingStarted, CargoUnloaded, ManifestClosed |
+| navigation | Route | PlanRoute, RecordDeparture, UpdatePosition, RecordArrival | RoutePlanned, ShipDeparted, PositionUpdated, ShipArrivedAtStation |
+| supply | Inventory | RecordStock, RequestResupply, DispatchResupply, ConfirmDelivery | StockRecorded, ResupplyRequested, ResupplyDispatched, DeliveryConfirmed |
+| station | Station | RegisterStation, RecordDocking, RecordCargoReceived, UpdateCapacity, DrainStock | StationRegistered, ShipDocked, CargoReceived, StationStockLow, CapacityUpdated, StockDrained |
+
+**Cross-service flows**: `Fleet:ShipDeparted → Navigation` · `Navigation:ShipArrivedAtStation → Cargo, Station` · `Station:StationStockLow → Supply` · `Supply:ResupplyDispatched → Fleet`.
+
+---
+
+## Kafka topics (15, all explicit, no auto-create)
+
+- Inbound: `canon.{service}.inbound`
+- Outbound: `canon.{service}.outbound`
+- Published events: `canon.{service}.events`
+
+---
+
+## Gateway (axum)
+
+- POST: `/fleet/ships`, `/fleet/ships/:id/route`, `/fleet/ships/:id/depart`, `/cargo/manifests`, `/cargo/manifests/:id/load`, `/navigation/routes`, `/supply/resupply`, `/stations/:id/register`
+- GET: `/stations/:id/inventory`, `/ships/:id/history`, `/cargo/manifests/:id`, `/replay/counterfactual`
+- WS: `/events` — `DemoEvent` JSON broadcast
+
+Per-service pools via `AppState::pool_for_service()`.
+
+### Bootstrap (idempotent on every gateway start)
+
+- Register 4 stations (Alpha 5000kg, Beta 3000kg, Gamma 2000kg, Delta 4000kg)
+- Seed stock: Alpha 85%, Beta 60%, Gamma 40%, Delta 75%
+- Register VSS Meridian (5000kg)
+- Stock-drain task starts after 15s.
+
+---
+
+## Deployment
+
+Backend: cross-compile macOS → linux/musl, slim alpine `COPY` images. **Never compile Rust inside Docker.** Frontend: WASM/Trunk inside Docker.
+
+```bash
+rustup target add aarch64-unknown-linux-musl
+brew install filosottile/musl-cross/musl-cross
+make k8s-up        # minikube
+make k8s-test-e2e  # Playwright smoke
+```
+
+Targets: `k8s-{up,down,build,deploy,status,logs,tunnel,restart,clean,test-e2e}`. Layout: `k8s/base/`, `k8s/overlays/{minikube,gke}/`. All pods in `canon` namespace; infra as StatefulSets+PVCs; init Jobs create schemas/keyspaces/topics.
+
+### GKE production — currently paused
+
+Live demo at `https://canon.mopjones.com` is **paused to save cost**. The static landing page + docs are served from GitHub Pages (`.github/workflows/pages.yml`); `/demo/` shows an offline page (`canon-site/demo/index.html`).
+
+Cluster `canon-demo` in `europe-west2-a`, 1 preemptible e2-standard-4. Registry `europe-west2-docker.pkg.dev/canon-demo-prod/canon/`. Auto-deploy disabled in `.github/workflows/deploy.yml` — uncomment the `push` trigger to re-enable.
+
+```bash
+make gke-cost-check   # show project billing
+make gke-pause        # scale to 0 nodes (~$2/mo, keeps PVCs)
+make gke-resume       # scale back to 1 node
+make gke-teardown     # delete cluster + IPs (irreversible — manifests remain)
+make gke-deploy       # manual deploy (when cluster exists)
+```
+
+**Auth gate** (optional, `CANON_AUTH_PASSWORD` env):
+- `X-Canon-Auth: <password>` (sets cookie) or `X-Canon-Debug: <key>` (CLI bypass).
+- Local secret files: `~/.canon-debug-key`, `~/.canon-auth-password` (never committed).
+
+```bash
+curl -H "X-Canon-Debug: $(cat ~/.canon-debug-key)" https://canon.mopjones.com/health
+CANON_AUTH_PASSWORD=$(cat ~/.canon-auth-password) npx playwright test
+kubectl set env deployment/gateway -n canon CANON_AUTH_PASSWORD=<pw>   # lock
+kubectl set env deployment/gateway -n canon CANON_AUTH_PASSWORD-       # unlock
+```
+
+---
+
+## Debugging — when the demo is broken
+
+Triage in this order. Do NOT skip.
+
+1. **API first.** `curl` and inspect:
+   ```bash
+   SID=$(curl -s -X POST https://canon.mopjones.com/sessions | python3 -c "import sys,json; print(json.load(sys.stdin)['session_id'])")
+   curl -s "https://canon.mopjones.com/game/$SID" | python3 -m json.tool
+   ```
+   `ship.status`, `ship.station_id`, `stations[].stock_pct`, `event_count` correct → bug is frontend. Stop touching infra.
+
+2. **API wrong** → check service logs:
+   ```bash
+   kubectl logs deployment/{fleet,navigation,station}-service -n canon-prod --tail=20
+   ```
+   Look for `ERROR`, `command processing failed`, `OffsetOutOfRange`.
+
+3. **`OffsetOutOfRange`** = Kafka lost data. Diagnose first. Test offset-clearing recovery in disposable env. **Never delete Kafka topics on prod.**
+
+4. **Frontend** — see `frontend/CLAUDE.md`.
+
+5. **Never nuke prod data.**
+
+---
+
+## Playwright DOM rules (Leptos re-renders detach elements)
+
+- **Never** `page.$()` + `handle.click()`. Use `page.locator(sel).click()` / `page.click(sel)`.
+- **Never** `page.$()` + `handle.evaluate()` for disabled checks. Use `page.locator(sel + ':not([disabled])').count()`.
+- Use `.dest-tab` class for destination buttons, not `:has-text("Alpha")`.
+- Wrap flight clicks in try/catch in stress tests.

--- a/canon-demo/Makefile
+++ b/canon-demo/Makefile
@@ -280,3 +280,45 @@ gke-monitoring-setup: ## Create uptime check and email alert (ALERT_EMAIL= requi
 		--combiner=OR \
 		--documentation='Canon prod (canon.mopjones.com) health check is failing.' && \
 	echo "==> Monitoring setup complete. Alerts will be sent to $(ALERT_EMAIL)."
+
+# ───── Cost-saving: pause / resume / teardown ──────────────────────────────
+GKE_CLUSTER ?= canon-demo
+GKE_ZONE    ?= europe-west2-a
+GCP_PROJECT ?= canon-demo-prod
+
+.PHONY: gke-pause
+gke-pause: ## Scale cluster to 0 nodes (keeps PVCs/config, ~$2/mo)
+	@echo "==> Scaling $(GKE_CLUSTER) to 0 nodes..."
+	gcloud container clusters resize $(GKE_CLUSTER) \
+		--zone=$(GKE_ZONE) --num-nodes=0 --quiet
+	@echo "==> Cluster paused. Resume with: make gke-resume"
+
+.PHONY: gke-resume
+gke-resume: ## Scale cluster back to 1 node
+	@echo "==> Scaling $(GKE_CLUSTER) to 1 node..."
+	gcloud container clusters resize $(GKE_CLUSTER) \
+		--zone=$(GKE_ZONE) --num-nodes=1 --quiet
+	@echo "==> Cluster resumed. Run: make gke-deploy when nodes are Ready"
+
+.PHONY: gke-teardown
+gke-teardown: ## DELETE cluster + reserved IPs (irreversible — manifests remain)
+	@echo "WARNING: this DELETES the GKE cluster, all PVCs, LBs, and reserved IPs."
+	@echo "Manifests in k8s/ are unaffected — rebuild later with: make gke-deploy"
+	@read -p "Type the cluster name '$(GKE_CLUSTER)' to confirm: " confirm; \
+		[ "$$confirm" = "$(GKE_CLUSTER)" ] || { echo "Aborted."; exit 1; }
+	@echo "==> Deleting cluster $(GKE_CLUSTER)..."
+	gcloud container clusters delete $(GKE_CLUSTER) \
+		--zone=$(GKE_ZONE) --project=$(GCP_PROJECT) --quiet || true
+	@echo "==> Listing reserved static IPs (delete manually if owned by canon):"
+	gcloud compute addresses list --project=$(GCP_PROJECT) || true
+	@echo "==> Listing forwarding rules (delete manually if owned by canon):"
+	gcloud compute forwarding-rules list --project=$(GCP_PROJECT) || true
+	@echo "==> Teardown complete. Artifact Registry images retained (~\$$1/mo)."
+	@echo "    To delete images: gcloud artifacts repositories delete canon \\"
+	@echo "      --location=europe-west2 --project=$(GCP_PROJECT)"
+
+.PHONY: gke-cost-check
+gke-cost-check: ## Open the GCP billing console for the project
+	@echo "==> Project: $(GCP_PROJECT)"
+	gcloud billing projects describe $(GCP_PROJECT) || true
+	@echo "==> Billing console: https://console.cloud.google.com/billing"

--- a/canon-demo/frontend/CLAUDE.md
+++ b/canon-demo/frontend/CLAUDE.md
@@ -1,0 +1,119 @@
+# frontend — Claude Code guide
+
+Leptos 0.7 CSR WASM, built with Trunk. Demo specifics: `../CLAUDE.md`. Framework: `../../CLAUDE.md`.
+
+---
+
+## Mockups (source of truth)
+
+- Demo app (`/demo`): `reference/mockup.html` — Live Fleet + Scenarios.
+- Landing page (`/`): `../../canon-site/reference/site-mockup.html`.
+
+Open the relevant mockup in a browser before writing code.
+
+- **Mockup is correct.** App differs → app is wrong. Extract CSS vars, colours, fonts, spacing, casing.
+- **Don't mimic** mockup DOM/inline JS. Use idiomatic reactive signals + composable components. Behaviour identical.
+- **Don't "improve"** away: no add/remove/rearrange of UI elements, fonts, colours, casing. A11y/responsive only if appearance/interaction unchanged.
+
+---
+
+## Hard rules
+
+- **No local simulation.** Every state change (ship movement, stock, oversight, event log) is driven by real events from the Canon pipeline (command → outbox → Kafka → event store → WebSocket). No local timers, no hardcoded event chains, no fire-and-forget POST fallbacks. Gateway down → show connection error.
+- **No interactive UI before `ready=true`.** Buttons/handlers disabled until the game projection returns `ready: true` (3–8s bootstrap). Disable all action buttons when `state.ships` is empty.
+- **No silent early returns** in `depart_ship`, `load_cargo`, `deliver_cargo`. Every `return` must set `pending_command`, set `command_error`, or log to console. Click that does nothing = bug.
+- **No hardcoded colours.** All via CSS custom properties.
+- **No `unwrap()`/`expect()`** outside tests.
+
+---
+
+## Design system
+
+Fonts (Google Fonts in `index.html`):
+- `Inter` 400/500/600/700 — headings, body, labels.
+- `JetBrains Mono` 400/600 — readouts, timestamps, badges, IDs, code.
+
+CSS vars in `style/main.css` (`:root` dark, `body.light` light): `--bg`, `--panel`, `--raised`, `--border`, `--borderhi`, `--cyan`, `--green`, `--amber`, `--red`, `--purple`, `--txt`, `--txthi`, `--txtlo`, `--mono`, `--sans`. Light is default. Theme toggle adds/removes `.light` on `<body>`. Starfield fades to `opacity:0` in light.
+
+---
+
+## Layout
+
+Two pages, nav tabs **inside the 56px header bar** (no separate nav row).
+
+- **Live Fleet** (default tab): single ship (VSS Meridian), user-controlled. Stations drain over time. Layout: header → map bar → canvas map (planets/ship/routes drawn on canvas, oversight strip absolute-bottom) → station cards (4 equal-width) → ship action bar → event log strip (≤160px, scrollable).
+- **Scenarios**: 5 mission cards → full-screen runner (step progress + narrative + action area + event log).
+
+Station positions (% canvas): Alpha 18% 26% green r32 · Beta 68% 14% purple r22 (ringed) · Gamma 76% 68% coral r28 · Delta 24% 74% blue r20.
+
+Supply loop Alpha→Beta→Gamma→Delta→Alpha. Drain per 3s tick: Alpha 0.15 (start 85%), Beta 0.20 (60%), Gamma 0.25 (40%), Delta 0.18 (75%). Correct delivery → +35%. 0% = game over.
+
+---
+
+## Scenario visualisations (animated, polished)
+
+- **01 Stranded Cargo (Oversight)** — gate card, two requirement rows ○→✓, badge amber→green.
+- **02 Ghost Ship (Snapshotting)** — counter 0→247 (~40ms tick) vs snapshot instant. Bar chart with speedup multiplier.
+- **03 Resupply Crisis (Cascade)** — 5 service nodes light up in sequence with animated arrows.
+- **04 Cassandra Incident (Dead letters)** — 3 DLQ cards with Requeue/Discard. Requeue red→green, discard fades.
+- **05 Duplicate Signal (Idempotency)** — two identical envelope cards. Trigger dedups second with red X. "ON CONFLICT DO NOTHING".
+
+---
+
+## Data sources
+
+Initial hydration:
+```
+GET /ships, /stations, /admin/oversight/windows, /admin/deadletters
+```
+
+Live: `WS /events`, 2s reconnect backoff. Tagged enum:
+```rust
+#[serde(tag = "type")]
+pub enum WsMessage {
+    Event(LiveEvent),
+    ShipUpdate(ShipState),
+    StationUpdate(StationState),
+    OversightUpdate(OversightWindow),
+    DeadLetter(DeadLetterEntry),
+    InfraStatus(InfraStatusMsg),
+}
+```
+
+In-memory signals = source of truth for rendering; the WS patches them. Signals only mutate from real WS messages or initial hydration.
+
+---
+
+## Build
+
+`Cargo.toml` and `Trunk.toml` are authoritative. `trunk build --release` must pass with zero errors.
+
+---
+
+## Acceptance (before merge)
+
+- `trunk build --release` clean.
+- Visual matches `reference/mockup.html` (colours/fonts/proportions/casing).
+- Fonts: Inter + JetBrains Mono only.
+- Ship moves only on user command, only when real WS event arrives.
+- Ship popup shows correct version/snapshot data.
+- Every UI state change driven by real pipeline events. Zero local simulation.
+- Gateway unreachable → connection error visible (no faked events).
+- Oversight strip shows live requirement state during voyages.
+- Correlation highlighting in event log via real correlation IDs.
+- All 5 scenarios complete, animated as specced.
+- Theme toggle works; starfield fades in light.
+- WS `/events` patches signals; initial 4 endpoints fetched on mount.
+- No hardcoded colours; no `unwrap`/`expect` outside tests.
+- `make k8s-up` deploys clean; `make k8s-test-e2e` Playwright passes.
+
+---
+
+## Frontend debugging
+
+If the API is correct (`curl /game/$SID`) but the UI is broken:
+
+- Buttons disabled/enabled correctly? Check `has_ship`, `is_pending`, `is_disconnected`.
+- `apply_snapshot` returning early because `ready=false`?
+- `depart_ship`/`load_cargo`/`deliver_cargo` silently returning?
+- Browser console errors?

--- a/canon-site/demo/index.html
+++ b/canon-site/demo/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo offline — Canon</title>
+  <meta name="description" content="The Canon live demo is temporarily offline.">
+  <meta name="robots" content="noindex">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style/main.css">
+  <style>
+    .offline-wrap{min-height:calc(100vh - 56px);display:flex;align-items:center;justify-content:center;padding:32px;}
+    .offline-card{max-width:640px;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:48px;text-align:center;box-shadow:0 8px 32px var(--shadow);}
+    .offline-status{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--amber);margin-bottom:24px;}
+    .offline-dot{width:8px;height:8px;border-radius:50%;background:var(--amber);box-shadow:0 0 12px var(--amber);animation:pulse 2s ease-in-out infinite;}
+    @keyframes pulse{0%,100%{opacity:1;}50%{opacity:.4;}}
+    .offline-title{font-family:var(--sans);font-size:42px;font-weight:700;color:var(--txthi);margin-bottom:16px;letter-spacing:-.02em;}
+    .offline-body{font-family:var(--sans);font-size:16px;line-height:1.6;color:var(--txt);margin-bottom:32px;}
+    .offline-body code{font-family:var(--mono);font-size:13px;background:var(--raised);padding:2px 6px;border-radius:4px;color:var(--txthi);}
+    .offline-ctas{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;}
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="hdr-left">
+    <a class="logo" href="/" style="margin-right:32px;text-decoration:none;color:inherit;">Canon</a>
+    <a class="nav-link" href="/">Home</a>
+    <a class="nav-link" href="/#features">Features</a>
+    <a class="nav-link" href="/docs">Docs</a>
+    <a class="nav-link active" href="/demo/">Demo</a>
+    <a class="nav-link" href="/codemap">Codemap</a>
+  </div>
+  <div class="hdr-r">
+    <a class="gh-link" href="https://github.com/rjh-mopjones/canon" target="_blank" rel="noopener">GitHub</a>
+    <div class="theme-btn" id="themeToggle">
+      <div class="trk"><div class="thmb"></div></div>
+      <span id="themeLabel">Dark</span>
+    </div>
+  </div>
+</header>
+
+<main class="offline-wrap">
+  <div class="offline-card">
+    <div class="offline-status"><span class="offline-dot"></span>Live demo offline</div>
+    <h1 class="offline-title">The fleet is grounded</h1>
+    <p class="offline-body">
+      The hosted demo cluster (5 services + Kafka, Cassandra, YugabyteDB on GKE) is paused
+      to keep running costs near zero. The framework itself is unaffected — you can still
+      run the full stack locally with <code>make k8s-up</code>, or read the docs and source.
+    </p>
+    <div class="offline-ctas">
+      <a class="cta cta-primary" href="/docs">Read the Docs &#8594;</a>
+      <a class="cta cta-secondary" href="https://github.com/rjh-mopjones/canon" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </div>
+</main>
+
+<script src="../js/site.js" defer></script>
+</body>
+</html>

--- a/canon-site/index.html
+++ b/canon-site/index.html
@@ -23,7 +23,7 @@
     <a class="nav-link active" href="#">Home</a>
     <a class="nav-link" href="#features">Features</a>
     <a class="nav-link" href="/docs">Docs</a>
-    <a class="nav-link" href="/demo">Demo</a>
+    <a class="nav-link demo-offline-link" href="/demo/">Demo <span class="demo-offline-badge">offline</span></a>
     <a class="nav-link" href="/codemap">Codemap</a>
   </div>
   <div class="hdr-r">
@@ -49,7 +49,7 @@
   </p>
   <div class="hero-ctas">
     <a class="cta cta-primary" href="/docs">Get Started &#8594;</a>
-    <a class="cta cta-secondary" href="/demo">See It Live</a>
+    <a class="cta cta-secondary demo-offline-link" href="/demo/">See It Live <span class="demo-offline-badge">offline</span></a>
   </div>
   <div class="hero-version">v0.1.0 &middot; Apache 2.0 &middot; Pure Rust</div>
 </section>
@@ -325,7 +325,7 @@
       <div class="demo-label l4">Delta Prime</div>
     </div>
   </div>
-  <a class="cta cta-primary" href="/demo">Play the Demo &#8594;</a>
+  <a class="cta cta-primary demo-offline-link" href="/demo/">Demo currently offline &#8594;<span class="demo-offline-badge" style="margin-left:8px;">paused</span></a>
 </section>
 
 <!-- ═══ FOOTER ═══ -->

--- a/canon-site/style/main.css
+++ b/canon-site/style/main.css
@@ -26,6 +26,7 @@ body.dark {
   --grid:rgba(212,135,94,.04);
   --shadow:rgba(0,0,0,.55);
 }
+.demo-offline-badge{display:inline-block;font-family:var(--mono);font-size:9px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;padding:2px 6px;margin-left:6px;border-radius:3px;background:var(--amberdim);color:var(--txthi);vertical-align:middle;}
 *{margin:0;padding:0;box-sizing:border-box;}
 html{scroll-behavior:smooth;}
 body{background:var(--bg);color:var(--txt);font-family:var(--sans);transition:background .3s,color .3s;overflow-x:hidden;}


### PR DESCRIPTION
## Summary
- Static site (landing + mdBook docs) deploys to GitHub Pages via new \`.github/workflows/pages.yml\`
- \`/demo/\` shows an offline page when the live cluster is paused
- GKE auto-deploy disabled (workflow_dispatch only) — re-enable by uncommenting the \`push\` trigger
- New Makefile targets: \`make gke-{pause,resume,teardown,cost-check}\`
- CLAUDE.md split into root + \`canon-demo/\` + \`canon-demo/frontend/\` for scoped context loading

## Why
GKE cluster is currently 2 × e2-standard-4 preemptible + StatefulSets (Yugabyte/Cassandra/Kafka/ZK), burning ~\$60-80/mo. The framework value is in the docs/source, not the live demo running 24/7.

## Cutover steps (after merge)
1. Repo Settings → Pages → Source: **GitHub Actions**
2. DNS: point \`canon.mopjones.com\` at GitHub Pages (CNAME \`rjh-mopjones.github.io\` or A records to GH Pages IPs)
3. Verify the Pages deploy at https://canon.mopjones.com
4. \`make gke-pause\` (cheap, reversible) or \`make gke-teardown\` (free, irreversible — manifests retained)

## Test plan
- [ ] \`pages.yml\` deploys cleanly (mdBook builds, \`_site\` populated, CNAME applied)
- [ ] https://canon.mopjones.com loads the landing page
- [ ] https://canon.mopjones.com/docs/ loads the mdBook
- [ ] https://canon.mopjones.com/demo/ shows the "fleet is grounded" offline page
- [ ] Demo nav link + CTA buttons display the \`offline\` badge
- [ ] \`make gke-cost-check\` succeeds locally
- [ ] \`make gke-pause\` then \`gcloud container clusters describe canon-demo\` shows 0 nodes